### PR TITLE
feat: add get webhook endpoint

### DIFF
--- a/packages/backend/routes/v1/connection/index.ts
+++ b/packages/backend/routes/v1/connection/index.ts
@@ -70,6 +70,21 @@ connectionRouter.post('/webhook', async (req, res) => {
     }
 });
 
+connectionRouter.get('/webhook', async (req, res) => {
+    try {
+        const result = await ConnectionService.getWebhook(req, res);
+        if (result.error) {
+            res.status(400).send(result);
+        } else {
+            res.send(result);
+        }
+    } catch (error: any) {
+        logError(error);
+        console.error('Could not fetch webhook', error);
+        res.status(500).send({ error: 'Internal server error' });
+    }
+});
+
 connectionRouter.delete('/webhook', async (req, res) => {
     try {
         const result = await ConnectionService.deleteWebhook(req, res);

--- a/packages/backend/services/connection.ts
+++ b/packages/backend/services/connection.ts
@@ -125,6 +125,29 @@ class ConnectionService {
             };
         }
     }
+    async getWebhook(
+        req: Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>,
+        _res: Response<any, Record<string, any>, number>
+    ) {
+        try {
+            const { 'x-revert-api-token': token, 'x-revert-t-id': tenantId } = req.headers;
+            const account = await prisma.accounts.findFirst({
+                where: {
+                    private_token: String(token),
+                },
+            });
+            const svixAppId = account!.id;
+            const webhook = await this.svix.endpoint.get(svixAppId, String(tenantId));
+            return { status: 'ok', webhook: webhook };
+        } catch (error: any) {
+            logError(error);
+            console.error(error);
+            return {
+                error: 'Error creating webhook!',
+                errorMessage: error,
+            };
+        }
+    }
 
     async deleteWebhook(
         req: Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>,

--- a/packages/backend/services/connection.ts
+++ b/packages/backend/services/connection.ts
@@ -143,7 +143,7 @@ class ConnectionService {
             logError(error);
             console.error(error);
             return {
-                error: 'Error creating webhook!',
+                error: 'Error fetching webhook!',
                 errorMessage: error,
             };
         }


### PR DESCRIPTION
### Description

Adds a `getWebhook` endpoint that allows you to check if a connection already has a webhook endpoint created for it. It gives an error if we search for a connection webhook that is not created. 

Fixes # (issue)

### Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

-   [x] Tested locally for connection webhooks that exist
-   [x] Tested locally for connection webhooks that don't exist

### Checklist:

-   [x] I have made corresponding changes to the documentation
