### PR TITLE
:herb: fix fern generate 

### DIFF
--- a/.github/workflows/deploy-fern-docs.yml
+++ b/.github/workflows/deploy-fern-docs.yml
@@ -20,7 +20,7 @@ jobs:
               with:
                   node-version: 17
             - name: Install Fern
-              run: npm install -g fern-api@0.6.12 && fern -v
+              run: npm install -g fern-api
 
             - name: Install Dependencies
               run: yarn install

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "packages/*"
     ],
     "devDependencies": {
-        "fern-api": "0.6.12",
+        "fern-api": "0.12.0",
         "prettier": "2.5.1",
         "pretty-quick": "3.1.3",
         "typescript": "^4.8.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6553,7 +6553,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@revertdotdev/main@workspace:."
   dependencies:
-    fern-api: 0.6.12
+    fern-api: 0.12.0
     prettier: 2.5.1
     pretty-quick: 3.1.3
     typescript: ^4.8.4
@@ -17993,12 +17993,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fern-api@npm:0.6.12":
-  version: 0.6.12
-  resolution: "fern-api@npm:0.6.12"
+"fern-api@npm:0.12.0":
+  version: 0.12.0
+  resolution: "fern-api@npm:0.12.0"
   bin:
     fern: cli.cjs
-  checksum: 91e4a3278795d742649856d46d1ac3262377d4597cf265fd7224e1e800e792c10f71e3eea778744c3d3d351e83e846fac22af1152ae14e2471b0d5c465d63e56
+  checksum: 1e93f846028139c15d2264162439de8b3786fe5f832b8d0cd47ca2ca3d656fdce5202357f9bf6ad675f900669a1400771d508fce1c5386d1f02bc53a36d103fa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The version of the `fern-api` package in `package.json` always need to line up with the version in `fern.config.json`. If they don't align you will see non-deterministic errors. 