### PR TITLE
fix: ensure ids are returned in CREATE endpoints for hubspot

### DIFF
--- a/packages/backend/services/crm/company.ts
+++ b/packages/backend/services/crm/company.ts
@@ -256,7 +256,7 @@ const companyService = new CompanyService(
 
                 switch (thirdPartyId) {
                     case TP_ID.hubspot: {
-                        await axios({
+                        const response = await axios({
                             method: 'post',
                             url: `https://api.hubapi.com/crm/v3/objects/companies/`,
                             headers: {
@@ -268,7 +268,7 @@ const companyService = new CompanyService(
                         res.send({
                             status: 'ok',
                             message: 'Hubspot company created',
-                            result: company,
+                            result: { id: response.data?.id, ...company },
                         });
                         break;
                     }

--- a/packages/backend/services/crm/contact.ts
+++ b/packages/backend/services/crm/contact.ts
@@ -249,7 +249,7 @@ const contactService = new ContactService(
 
                 switch (thirdPartyId) {
                     case TP_ID.hubspot: {
-                        await axios({
+                        const response = await axios({
                             method: 'post',
                             url: `https://api.hubapi.com/crm/v3/objects/contacts/`,
                             headers: {
@@ -261,7 +261,7 @@ const contactService = new ContactService(
                         res.send({
                             status: 'ok',
                             message: 'Hubspot contact created',
-                            result: contact,
+                            result: { id: response.data?.id, ...contact },
                         });
                         break;
                     }

--- a/packages/backend/services/crm/deal.ts
+++ b/packages/backend/services/crm/deal.ts
@@ -251,7 +251,7 @@ const dealService = new DealService(
 
                 switch (thirdPartyId) {
                     case TP_ID.hubspot: {
-                        await axios({
+                        const response = await axios({
                             method: 'post',
                             url: `https://api.hubapi.com/crm/v3/objects/deals/`,
                             headers: {
@@ -263,7 +263,7 @@ const dealService = new DealService(
                         res.send({
                             status: 'ok',
                             message: 'Hubspot deal created',
-                            result: deal,
+                            result: { id: response.data?.id, ...deal },
                         });
                         break;
                     }

--- a/packages/backend/services/crm/event.ts
+++ b/packages/backend/services/crm/event.ts
@@ -249,7 +249,7 @@ const eventService = new EventService(
 
                 switch (thirdPartyId) {
                     case TP_ID.hubspot: {
-                        await axios({
+                        const response = await axios({
                             method: 'post',
                             url: `https://api.hubapi.com/crm/v3/objects/meetings/`,
                             headers: {
@@ -258,7 +258,11 @@ const eventService = new EventService(
                             },
                             data: JSON.stringify(event),
                         });
-                        res.send({ status: 'ok', message: 'Hubspot event created', result: event });
+                        res.send({
+                            status: 'ok',
+                            message: 'Hubspot event created',
+                            result: { id: response.data?.id, ...event },
+                        });
                         break;
                     }
                     case TP_ID.zohocrm: {

--- a/packages/backend/services/crm/lead.ts
+++ b/packages/backend/services/crm/lead.ts
@@ -261,7 +261,7 @@ const leadService = new LeadService(
 
                 switch (thirdPartyId) {
                     case TP_ID.hubspot: {
-                        await axios({
+                        const response = await axios({
                             method: 'post',
                             url: `https://api.hubapi.com/crm/v3/objects/contacts/`,
                             headers: {
@@ -273,7 +273,7 @@ const leadService = new LeadService(
                         res.send({
                             status: 'ok',
                             message: 'Hubspot lead created',
-                            result: lead,
+                            result: { id: response.data?.id, ...lead },
                         });
                         break;
                     }

--- a/packages/backend/services/crm/task.ts
+++ b/packages/backend/services/crm/task.ts
@@ -245,7 +245,7 @@ const taskService = new TaskService(
 
                 switch (thirdPartyId) {
                     case TP_ID.hubspot: {
-                        await axios({
+                        const response = await axios({
                             method: 'post',
                             url: `https://api.hubapi.com/crm/v3/objects/tasks/`,
                             headers: {
@@ -257,7 +257,7 @@ const taskService = new TaskService(
                         res.send({
                             status: 'ok',
                             message: 'Hubspot task created',
-                            result: task,
+                            result: { id: response.data?.id, ...task },
                         });
                         break;
                     }

--- a/packages/backend/services/crm/user.ts
+++ b/packages/backend/services/crm/user.ts
@@ -245,7 +245,7 @@ const userService = new UserService(
 
                 switch (thirdPartyId) {
                     case TP_ID.hubspot: {
-                        await axios({
+                        const response = await axios({
                             method: 'post',
                             url: `https://api.hubapi.com/settings/v3/users`,
                             headers: {
@@ -257,7 +257,7 @@ const userService = new UserService(
                         res.send({
                             status: 'ok',
                             message: 'Hubspot user created',
-                            result: user,
+                            result: { id: response.data?.id, ...user },
                         });
                         break;
                     }


### PR DESCRIPTION
### Description

Ensures ids (remote) are returned while creating objects with our APIs. 

### Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

-   [x] Tested new fields are returned
-   [x] Tested old fields are in tact

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
