### PR TITLE
fix: create apps only when not present

### DIFF
--- a/packages/backend/services/auth.ts
+++ b/packages/backend/services/auth.ts
@@ -280,14 +280,18 @@ class AuthService {
                     },
                     include: { environments: true },
                 });
-                // Create default apps.
+                // Create default apps that don't yet exist.
                 await Promise.all(
                     Object.keys(ENV).map((env) => {
                         Object.keys(TP_ID).map(async (tp) => {
                             try {
                                 const environment = account.environments?.find((e) => e.env === env)!;
-                                await prisma.apps.create({
-                                    data: {
+                                await prisma.apps.upsert({
+                                    where: {
+                                        id: `${tp}_${account.id}_${env}`,
+                                    },
+                                    update: {},
+                                    create: {
                                         id: `${tp}_${account.id}_${env}`,
                                         tp_id: tp as TP_ID,
                                         scope: [],


### PR DESCRIPTION
### Description

Create apps only when not present for an account. So far, the code was trying to create multiple entries for apps even when the apps are present for an account when a new user signs up. 


### Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

