### PR TITLE
Corrected pipedrive email target field

### DIFF
--- a/packages/backend/prisma/seed.ts
+++ b/packages/backend/prisma/seed.ts
@@ -126,7 +126,7 @@ async function main() {
             {
                 source_field_name: {
                     [TP_ID.hubspot]: 'email',
-                    [TP_ID.pipedrive]: 'phone.0.value',
+                    [TP_ID.pipedrive]: 'email.0.value',
                     [TP_ID.sfdc]: 'Email',
                     [TP_ID.zohocrm]: 'Email',
                 },


### PR DESCRIPTION
According to pipedrive [docs](https://developers.pipedrive.com/docs/api/v1/Persons#getPersons) email is returned in its own array of object.

### Type of change

-   [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
