### PR TITLE
chore(dev-ex): make moesif optional for local dev

### DIFF
--- a/packages/backend/index.ts
+++ b/packages/backend/index.ts
@@ -97,21 +97,22 @@ const testv2Router = (_req: Request, res: Response) => {
     res.send({ data: 'v2 hit' });
 };
 
-// 2. Set the options, the only required field is applicationId
-const moesifMiddleware = moesif({
-    applicationId: config.MOESIF_APPLICATION_ID!,
-    debug: process.env.NODE_ENV !== 'production', // enable debug mode.
-    logBody: true,
-    // Optional hook to link API calls to users
-    identifyUser: function (req: any, _: any) {
-        return req.headers['x-revert-t-id'] ? req.headers['x-revert-t-id'] : undefined;
-    },
-    identifyCompany: function (_: any, res: any) {
-        return res.locals?.account?.id;
-    },
-});
-
-app.use(moesifMiddleware);
+if (config.MOESIF_APPLICATION_ID) {
+    // Set the options, the only required field is applicationId
+    const moesifMiddleware = moesif({
+        applicationId: config.MOESIF_APPLICATION_ID!,
+        debug: process.env.NODE_ENV !== 'production', // enable debug mode.
+        logBody: true,
+        // Optional hook to link API calls to users
+        identifyUser: function (req: any, _: any) {
+            return req.headers['x-revert-t-id'] ? req.headers['x-revert-t-id'] : undefined;
+        },
+        identifyCompany: function (_: any, res: any) {
+            return res.locals?.account?.id;
+        },
+    });
+    app.use(moesifMiddleware);
+}
 
 app.use(
     '/',


### PR DESCRIPTION
### Description

Makes Moesif an option config for running Revert backend. 

### Type of change

-   [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

-   [x] Tested with and without the `.env` variables

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
