### PR TITLE
fix: only call `onClose` when passed via props

### DIFF
--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -308,7 +308,9 @@ const createIntegrationBlock = function (self, integration) {
                 rootElement.firstChild.remove();
             }
             this.state = 'close';
-            this.#onClose();
+            if (this.#onClose) {
+                this.#onClose();
+            }
         };
 
         renderInitialStage = function (integrationId) {


### PR DESCRIPTION
### Description

As described our users 

```
So we open the hubspot auth page in a new tab with this code -
revertConnect?.open?.("hubspot")
It does open it in a new tab but then we also receive the error in the screenshot,
We were making an api call after the above mentioned line and it was not getting called due to this error.
For now we are making the api call before executing the open function from Revert as a temporary solution.


We are currently using
"@revertdotdev/revert-react": "^0.0.15", 

``` 


### Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

-   [x] Tested locally and staging

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
