### PR TITLE
fix: update docs accent color

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -60,7 +60,7 @@ navigation:
       layout:
           - api: API Reference
 colors:
-    accentPrimary: '#ffffff'
+    accentPrimary: '#2047d0'
 logo:
     dark: ./docs/assets/logo.png
     light: ./docs/assets/logo.png


### PR DESCRIPTION
### Description

update docs accent color to an on brand color

<img width="1602" alt="Screenshot 2023-11-17 at 1 14 53 PM" src="https://github.com/revertinc/revert/assets/7681067/31d38d2c-2d1f-472f-bdcf-43ba2fb268cc">


Also filed with an issue with Fern: https://github.com/fern-api/fern/issues/2288 

### Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] This change requires a documentation update

