### PR TITLE
fix: Updated win32 script to automatically create build folders

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -6,7 +6,7 @@
         "dev": "concurrently --kill-others \"yarn run watch:ts\" \"yarn workspace @revertdotdev/revert-react dev\"",
         "watch:ts": "run-script-os",
         "watch:ts:default": "nodemon -w src/index.ts --exec \"yarn run build && cp dist/revert.js ../react/src/lib/build/revert-dev.js && cp dist/revert.js ../vue/src/lib/build/revert-dev.js\"",
-        "watch:ts:win32": "nodemon -w src/index.ts --exec \"yarn run build && xcopy /s /y dist\\revert.js ..\\react\\src\\lib\\build\\revert-dev.js && echo F | xcopy /s /y dist\\revert.js ..\\vue\\src\\lib\\build\\revert-dev.js\"",
+        "watch:ts:win32": "nodemon -w src/index.ts --exec \"yarn run build && xcopy /y dist\\revert.js ..\\react\\src\\lib\\build\\revert-dev.js*  && xcopy /y dist\\revert.js ..\\vue\\src\\lib\\build\\revert-dev.js*\"",
         "test": "npm test",
         "build": "npm run prebuild && vite build",
         "prebuild": "tsc && babel src -d lib && browserify lib/index.js -o lib/bundle.js",


### PR DESCRIPTION
### Description

Build directories `packages/react/lib/build/revert-dev.js` and `packages/vue/lib/build/revert-dev.js`  automatic generation.

### Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

-   [X] By executing `yarn workspace @revertdotdev/js dev`

### Checklist:

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings
