### PR TITLE
fix: Multiple tenantId and tp_id conflict

### DIFF
--- a/packages/backend/prisma/client.ts
+++ b/packages/backend/prisma/client.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Prisma } from '@prisma/client';
+import { PrismaClient, Prisma, TP_ID } from '@prisma/client';
 import config from '../config';
 import gcm from '../helpers/gcmUtil';
 
@@ -22,6 +22,39 @@ const xprisma = prisma.$extends({
                 if (args.create?.tp_customer_id) {
                     args.create.tp_customer_id = gcm.encrypt(args.create.tp_customer_id, config.AES_ENCRYPTION_SECRET);
                 }
+
+                // prepend environment Id to the t_id. connectionId = environmentId_t_id
+                if (args.where?.id && args.create?.environmentId) {
+                    const newConnectionId = `${args.create.environmentId}_${args.where.id}`;
+                    args.where.id = newConnectionId;
+                    args.create.id = newConnectionId;
+                }
+
+                if (args.update?.tp_id !== TP_ID.discord) {
+                    args.update.app_bot_token = null;
+                }
+
+                // tp_account_url: zohocrm sfdc pipedrive jira
+                if (args.update?.tp_id) {
+                    const tpId = args.update.tp_id;
+                    if (
+                        !(
+                            tpId === TP_ID.zohocrm ||
+                            tpId === TP_ID.sfdc ||
+                            tpId === TP_ID.pipedrive ||
+                            tpId === TP_ID.jira
+                        )
+                    ) {
+                        args.update.tp_account_url = null;
+                    }
+                }
+
+                if (args.update?.tp_customer_id) {
+                    // when same t_id is used to update with other app
+                    const thirdPartyCustomerId: any = args.update.tp_customer_id;
+                    args.update.tp_customer_id = gcm.encrypt(thirdPartyCustomerId, config.AES_ENCRYPTION_SECRET);
+                }
+
                 return query(args);
             },
         },

--- a/packages/backend/prisma/client.ts
+++ b/packages/backend/prisma/client.ts
@@ -25,7 +25,7 @@ const xprisma = prisma.$extends({
 
                 // prepend environment Id to the t_id. connectionId = environmentId_t_id
                 if (args.where?.id && args.create?.environmentId) {
-                    const newConnectionId = `${args.create.environmentId}_${args.where.id}`;
+                    const newConnectionId = `${args.create.environmentId}_${args.create.tp_id}_${args.where.id}`;
                     args.where.id = newConnectionId;
                     args.create.id = newConnectionId;
                 }

--- a/packages/backend/prisma/client.ts
+++ b/packages/backend/prisma/client.ts
@@ -25,7 +25,7 @@ const xprisma = prisma.$extends({
 
                 // prepend environment Id to the t_id. connectionId = environmentId_t_id
                 if (args.where?.id && args.create?.environmentId) {
-                    const newConnectionId = `${args.create.environmentId}_${args.create.tp_id}_${args.where.id}`;
+                    const newConnectionId = `${args.create.environmentId}_${args.where.id}`;
                     args.where.id = newConnectionId;
                     args.create.id = newConnectionId;
                 }

--- a/packages/backend/prisma/connectionIdMigrate.ts
+++ b/packages/backend/prisma/connectionIdMigrate.ts
@@ -1,0 +1,41 @@
+import { PrismaClient } from '@prisma/client';
+import { xprisma } from './client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+    const allConnections = await xprisma.connections.findMany({
+        include: {
+            app: {
+                select: {
+                    environmentId: true,
+                    tp_id: true,
+                    id: true,
+                },
+            },
+        },
+    });
+
+    allConnections.forEach(async (connection) => {
+        const environmentId = connection.app?.environmentId;
+        const newConnectionId = `${environmentId}_${connection.id}`;
+        await prisma.connections.update({
+            where: {
+                id: connection.id,
+            },
+            data: {
+                id: newConnectionId,
+                environmentId: environmentId,
+            },
+        });
+    });
+}
+main()
+    .then(async () => {
+        await prisma.$disconnect();
+    })
+    .catch(async (e) => {
+        console.error(e);
+        await prisma.$disconnect();
+        process.exit(1);
+    });

--- a/packages/backend/prisma/connectionIdMigrate.ts
+++ b/packages/backend/prisma/connectionIdMigrate.ts
@@ -19,15 +19,19 @@ async function main() {
     allConnections.forEach(async (connection) => {
         const environmentId = connection.app?.environmentId;
         const newConnectionId = `${environmentId}_${connection.id}`;
-        await prisma.connections.update({
-            where: {
-                id: connection.id,
-            },
-            data: {
-                id: newConnectionId,
-                environmentId: environmentId,
-            },
-        });
+        try {
+            await prisma.connections.update({
+                where: {
+                    id: connection.id,
+                },
+                data: {
+                    id: newConnectionId,
+                    environmentId: environmentId,
+                },
+            });
+        } catch (error) {
+            console.log('error', environmentId, newConnectionId, connection.id, error);
+        }
     });
 }
 main()

--- a/packages/backend/prisma/migrations/20240129132405_unique_third_party_per_environment_constraint_environments_connection_relation_added/migration.sql
+++ b/packages/backend/prisma/migrations/20240129132405_unique_third_party_per_environment_constraint_environments_connection_relation_added/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[tp_id,environmentId]` on the table `connections` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "connections" ADD COLUMN     "environmentId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "connections_tp_id_environmentId_key" ON "connections"("tp_id", "environmentId");
+
+-- AddForeignKey
+ALTER TABLE "connections" ADD CONSTRAINT "connections_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "environments"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/backend/prisma/migrations/20240129175309_unique_third_party_per_tenant_per_environment_constraint_added/migration.sql
+++ b/packages/backend/prisma/migrations/20240129175309_unique_third_party_per_tenant_per_environment_constraint_added/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[tp_id,t_id,environmentId]` on the table `connections` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "connections_tp_id_environmentId_key";
+
+-- DropIndex
+DROP INDEX "connections_tp_id_t_id_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "connections_tp_id_t_id_environmentId_key" ON "connections"("tp_id", "t_id", "environmentId");

--- a/packages/backend/prisma/migrations/20240130012345_unique_third_party_per_environment_order_changed/migration.sql
+++ b/packages/backend/prisma/migrations/20240130012345_unique_third_party_per_environment_order_changed/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[tp_id,environmentId]` on the table `connections` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[tp_id,t_id]` on the table `connections` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "connections_tp_id_t_id_environmentId_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "connections_tp_id_environmentId_key" ON "connections"("tp_id", "environmentId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "connections_tp_id_t_id_key" ON "connections"("tp_id", "t_id");

--- a/packages/backend/prisma/migrations/20240130012936_unique_third_party_per_tenant_per_environment_added/migration.sql
+++ b/packages/backend/prisma/migrations/20240130012936_unique_third_party_per_tenant_per_environment_added/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[tp_id,t_id,environmentId]` on the table `connections` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "connections_tp_id_t_id_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "connections_tp_id_t_id_environmentId_key" ON "connections"("tp_id", "t_id", "environmentId");

--- a/packages/backend/prisma/migrations/20240130121018_unique_tenant_per_environment_constraint_added/migration.sql
+++ b/packages/backend/prisma/migrations/20240130121018_unique_tenant_per_environment_constraint_added/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[t_id,environmentId]` on the table `connections` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "connections_t_id_environmentId_key" ON "connections"("t_id", "environmentId");

--- a/packages/backend/prisma/migrations/20240130121641_/migration.sql
+++ b/packages/backend/prisma/migrations/20240130121641_/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "connections_t_id_environmentId_key";

--- a/packages/backend/prisma/migrations/20240130130301_/migration.sql
+++ b/packages/backend/prisma/migrations/20240130130301_/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[t_id,environmentId]` on the table `connections` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "connections_t_id_environmentId_key" ON "connections"("t_id", "environmentId");

--- a/packages/backend/prisma/migrations/20240131115131_1/migration.sql
+++ b/packages/backend/prisma/migrations/20240131115131_1/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "connections_tp_id_environmentId_key";

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -103,9 +103,8 @@ model connections {
   updatedAt                  DateTime        @default(now()) @updatedAt
 
   @@unique([tp_customer_id, t_id], name: "uniqueCustomerPerTenant")
-  @@unique([tp_id, t_id], name: "uniqueThirdPartyPerTenant")
+  @@unique([tp_id, t_id, environmentId], name: "uniqueThirdPartyPerTenantPerEnvironment")
   @@unique([tp_customer_id, t_id, tp_id], name: "uniqueCustomerPerTenantPerThirdParty")
-  @@unique([tp_id, environmentId], name: "uniqueThirdPartyPerEnvironment")
 }
 
 model schema_mapping {

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -43,16 +43,16 @@ model accounts {
 }
 
 model environments {
-  id            String    @id
+  id            String        @id
   env           ENV
-  private_token String    @unique
-  public_token  String    @unique
-  accounts      accounts? @relation(fields: [accountId], references: [id])
+  private_token String        @unique
+  public_token  String        @unique
+  accounts      accounts?     @relation(fields: [accountId], references: [id])
   accountId     String
   apps          apps[]
   connections   connections[]
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @default(now()) @updatedAt
+  createdAt     DateTime      @default(now())
+  updatedAt     DateTime      @default(now()) @updatedAt
 }
 
 model apps {
@@ -97,13 +97,12 @@ model connections {
   appId                      String?
   schema_mapping_id          String?
   schema_mapping             schema_mapping? @relation(fields: [schema_mapping_id], references: [id])
-  environemnt                environments?    @relation(fields: [environmentId], references: [id])
+  environemnt                environments?   @relation(fields: [environmentId], references: [id])
   environmentId              String?
   createdAt                  DateTime        @default(now())
   updatedAt                  DateTime        @default(now()) @updatedAt
 
   @@unique([tp_customer_id, t_id], name: "uniqueCustomerPerTenant")
-  @@unique([tp_id, environmentId], name: "uniqueThirdPartyPerEnvironment")
   @@unique([t_id, environmentId], name: "uniqueTenantPerEnvironment")
   @@unique([tp_id, t_id, environmentId], name: "uniqueThirdPartyPerTenantPerEnvironment")
   @@unique([tp_customer_id, t_id, tp_id], name: "uniqueCustomerPerTenantPerThirdParty")

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -103,6 +103,7 @@ model connections {
   updatedAt                  DateTime        @default(now()) @updatedAt
 
   @@unique([tp_customer_id, t_id], name: "uniqueCustomerPerTenant")
+  @@unique([tp_id, environmentId], name: "uniqueThirdPartyPerEnvironment")
   @@unique([tp_id, t_id, environmentId], name: "uniqueThirdPartyPerTenantPerEnvironment")
   @@unique([tp_customer_id, t_id, tp_id], name: "uniqueCustomerPerTenantPerThirdParty")
 }

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -104,6 +104,7 @@ model connections {
 
   @@unique([tp_customer_id, t_id], name: "uniqueCustomerPerTenant")
   @@unique([tp_id, environmentId], name: "uniqueThirdPartyPerEnvironment")
+  @@unique([t_id, environmentId], name: "uniqueTenantPerEnvironment")
   @@unique([tp_id, t_id, environmentId], name: "uniqueThirdPartyPerTenantPerEnvironment")
   @@unique([tp_customer_id, t_id, tp_id], name: "uniqueCustomerPerTenantPerThirdParty")
 }

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -50,6 +50,7 @@ model environments {
   accounts      accounts? @relation(fields: [accountId], references: [id])
   accountId     String
   apps          apps[]
+  connections   connections[]
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @default(now()) @updatedAt
 }
@@ -96,12 +97,15 @@ model connections {
   appId                      String?
   schema_mapping_id          String?
   schema_mapping             schema_mapping? @relation(fields: [schema_mapping_id], references: [id])
+  environemnt                environments?    @relation(fields: [environmentId], references: [id])
+  environmentId              String?
   createdAt                  DateTime        @default(now())
   updatedAt                  DateTime        @default(now()) @updatedAt
 
   @@unique([tp_customer_id, t_id], name: "uniqueCustomerPerTenant")
   @@unique([tp_id, t_id], name: "uniqueThirdPartyPerTenant")
   @@unique([tp_customer_id, t_id, tp_id], name: "uniqueCustomerPerTenantPerThirdParty")
+  @@unique([tp_id, environmentId], name: "uniqueThirdPartyPerEnvironment")
 }
 
 model schema_mapping {

--- a/packages/backend/routes/v1/chat/auth.ts
+++ b/packages/backend/routes/v1/chat/auth.ts
@@ -95,6 +95,9 @@ authRouter.get('/oauth-callback', async (req, res) => {
                         tp_refresh_token: result.data?.refresh_token,
                         app_client_id: clientId || config.SLACK_CLIENT_ID,
                         app_client_secret: clientSecret || config.SLACK_CLIENT_SECRET,
+                        tp_id: integrationId,
+                        appId: account?.apps[0].id,
+                        tp_customer_id: String(info.data.user?.id),
                     },
                     create: {
                         id: String(req.query.t_id),
@@ -184,6 +187,9 @@ authRouter.get('/oauth-callback', async (req, res) => {
                         app_client_id: clientId || config.DISCORD_CLIENT_ID,
                         app_client_secret: clientSecret || config.DISCORD_CLIENT_SECRET,
                         app_bot_token: botToken || config.DISCORD_BOT_TOKEN,
+                        tp_id: integrationId,
+                        appId: account?.apps[0].id,
+                        tp_customer_id: guildId,
                     },
                     create: {
                         id: String(req.query.t_id),

--- a/packages/backend/routes/v1/chat/auth.ts
+++ b/packages/backend/routes/v1/chat/auth.ts
@@ -50,7 +50,7 @@ authRouter.get('/oauth-callback', async (req, res) => {
         const clientSecret = account?.apps[0]?.is_revert_app ? undefined : account?.apps[0]?.app_client_secret;
         const botToken = account?.apps[0]?.is_revert_app ? undefined : account?.apps[0]?.app_bot_token;
         const svixAppId = account!.accounts!.id;
-
+        const environmentId = account?.id;
         if (integrationId === TP_ID.slack && req.query.code && req.query.t_id && revertPublicKey) {
             // handling the slack received code
             const url = 'https://slack.com/api/oauth.v2.access';
@@ -107,6 +107,7 @@ authRouter.get('/oauth-callback', async (req, res) => {
                         tp_customer_id: String(info.data.user?.id),
                         owner_account_public_token: revertPublicKey,
                         appId: account?.apps[0].id,
+                        environmentId: environmentId,
                     },
                 });
                 // Svix stuff goes here ****
@@ -196,6 +197,7 @@ authRouter.get('/oauth-callback', async (req, res) => {
                         tp_customer_id: guildId,
                         owner_account_public_token: revertPublicKey,
                         appId: account?.apps[0].id,
+                        environmentId: environmentId,
                     },
                 });
 

--- a/packages/backend/routes/v1/crm/auth.ts
+++ b/packages/backend/routes/v1/crm/auth.ts
@@ -80,6 +80,9 @@ authRouter.get('/oauth-callback', async (req, res) => {
                         tp_refresh_token: result.data.refresh_token,
                         app_client_id: clientId || config.HUBSPOT_CLIENT_ID,
                         app_client_secret: clientSecret || config.HUBSPOT_CLIENT_SECRET,
+                        tp_id: integrationId,
+                        appId: account?.apps[0].id,
+                        tp_customer_id: info.data.user,
                     },
                     create: {
                         id: String(req.query.t_id),
@@ -197,6 +200,12 @@ authRouter.get('/oauth-callback', async (req, res) => {
                         update: {
                             tp_access_token: result.data.access_token,
                             tp_refresh_token: result.data.refresh_token,
+                            app_client_id: clientId || config.ZOHOCRM_CLIENT_ID,
+                            app_client_secret: clientSecret || config.ZOHOCRM_CLIENT_SECRET,
+                            tp_id: integrationId,
+                            appId: account?.apps[0].id,
+                            tp_customer_id: info.data.Email,
+                            tp_account_url: req.query.accountURL as string,
                         },
                     });
                     config.svix?.message.create(svixAppId, {
@@ -293,6 +302,10 @@ authRouter.get('/oauth-callback', async (req, res) => {
                         tp_refresh_token: result.data.refresh_token,
                         app_client_id: clientId || config.SFDC_CLIENT_ID,
                         app_client_secret: clientSecret || config.SFDC_CLIENT_SECRET,
+                        tp_id: integrationId,
+                        appId: account?.apps[0].id,
+                        tp_customer_id: info.data.email,
+                        tp_account_url: info.data.urls['custom_domain'],
                     },
                 });
                 config.svix?.message.create(svixAppId, {
@@ -374,6 +387,12 @@ authRouter.get('/oauth-callback', async (req, res) => {
                     update: {
                         tp_access_token: result.data.access_token,
                         tp_refresh_token: result.data.refresh_token,
+                        app_client_id: clientId || config.PIPEDRIVE_CLIENT_ID,
+                        app_client_secret: clientSecret || config.PIPEDRIVE_CLIENT_SECRET,
+                        tp_id: integrationId,
+                        appId: account?.apps[0].id,
+                        tp_customer_id: info.data.data.email,
+                        tp_account_url: result.data.api_domain,
                     },
                     create: {
                         id: String(req.query.t_id),
@@ -464,6 +483,9 @@ authRouter.get('/oauth-callback', async (req, res) => {
                         tp_refresh_token: result.data.refresh_token,
                         app_client_id: clientId || config.HUBSPOT_CLIENT_ID,
                         app_client_secret: clientSecret || config.HUBSPOT_CLIENT_SECRET,
+                        tp_id: integrationId,
+                        appId: account?.apps[0].id,
+                        tp_customer_id: info.data.email,
                     },
                     create: {
                         id: String(req.query.t_id),

--- a/packages/backend/routes/v1/crm/auth.ts
+++ b/packages/backend/routes/v1/crm/auth.ts
@@ -44,6 +44,7 @@ authRouter.get('/oauth-callback', async (req, res) => {
         const clientId = account?.apps[0]?.is_revert_app ? undefined : account?.apps[0]?.app_client_id;
         const clientSecret = account?.apps[0]?.is_revert_app ? undefined : account?.apps[0]?.app_client_secret;
         const svixAppId = account!.accounts!.id;
+        const environmentId = account?.id;
 
         if (integrationId === TP_ID.hubspot && req.query.code && req.query.t_id && revertPublicKey) {
             // Handle the received code
@@ -91,6 +92,7 @@ authRouter.get('/oauth-callback', async (req, res) => {
                         tp_customer_id: info.data.user,
                         owner_account_public_token: revertPublicKey,
                         appId: account?.apps[0].id,
+                        environmentId: environmentId,
                     },
                 });
                 config.svix?.message.create(svixAppId, {
@@ -190,6 +192,7 @@ authRouter.get('/oauth-callback', async (req, res) => {
                             app_client_secret: clientSecret || config.ZOHOCRM_CLIENT_SECRET,
                             owner_account_public_token: revertPublicKey,
                             appId: account?.apps[0].id,
+                            environmentId: environmentId,
                         },
                         update: {
                             tp_access_token: result.data.access_token,
@@ -283,6 +286,7 @@ authRouter.get('/oauth-callback', async (req, res) => {
                         app_client_secret: clientSecret || config.SFDC_CLIENT_SECRET,
                         owner_account_public_token: revertPublicKey,
                         appId: account?.apps[0].id,
+                        environmentId: environmentId,
                     },
                     update: {
                         tp_access_token: result.data.access_token,
@@ -381,6 +385,7 @@ authRouter.get('/oauth-callback', async (req, res) => {
                         owner_account_public_token: revertPublicKey,
                         tp_account_url: result.data.api_domain,
                         appId: account?.apps[0].id,
+                        environmentId: environmentId,
                     },
                 });
                 config.svix?.message.create(svixAppId, {
@@ -471,6 +476,7 @@ authRouter.get('/oauth-callback', async (req, res) => {
                         tp_customer_id: info.data.email,
                         owner_account_public_token: revertPublicKey,
                         appId: account?.apps[0].id,
+                        environmentId: environmentId,
                     },
                 });
 

--- a/packages/backend/routes/v1/ticket/auth.ts
+++ b/packages/backend/routes/v1/ticket/auth.ts
@@ -38,7 +38,7 @@ authRouter.get('/oauth-callback', async (req, res) => {
         const clientId = account?.apps[0]?.is_revert_app ? undefined : account?.apps[0]?.app_client_id;
         const clientSecret = account?.apps[0]?.is_revert_app ? undefined : account?.apps[0]?.app_client_secret;
         const svixAppId = account!.accounts!.id;
-
+        const environmentId = account?.id;
         if (integrationId === TP_ID.linear && req.query.code && req.query.t_id && revertPublicKey) {
             // Handle the received code
             const url = `https://api.linear.app/oauth/token`;
@@ -100,6 +100,7 @@ authRouter.get('/oauth-callback', async (req, res) => {
                         tp_customer_id: String(info.data.viewer?.id),
                         owner_account_public_token: revertPublicKey,
                         appId: account?.apps[0].id,
+                        environmentId: environmentId,
                     },
                 });
 
@@ -193,6 +194,7 @@ authRouter.get('/oauth-callback', async (req, res) => {
                         tp_customer_id: String(info.data?.user?.id),
                         owner_account_public_token: revertPublicKey,
                         appId: account?.apps[0].id,
+                        environmentId: environmentId,
                     },
                 });
 
@@ -311,6 +313,7 @@ authRouter.get('/oauth-callback', async (req, res) => {
                         tp_customer_id: String(info.id),
                         owner_account_public_token: revertPublicKey,
                         appId: account?.apps[0].id,
+                        environmentId: environmentId,
                     },
                 });
 
@@ -424,6 +427,7 @@ authRouter.get('/oauth-callback', async (req, res) => {
                         app_client_secret: clientSecret || config.JIRA_CLIENT_SECRET,
                         owner_account_public_token: revertPublicKey,
                         appId: account?.apps[0].id,
+                        environmentId: environmentId,
                     },
                     update: {
                         tp_access_token: result.data.access_token,

--- a/packages/backend/routes/v1/ticket/auth.ts
+++ b/packages/backend/routes/v1/ticket/auth.ts
@@ -87,8 +87,12 @@ authRouter.get('/oauth-callback', async (req, res) => {
                     },
                     update: {
                         tp_access_token: result.data?.access_token,
+                        tp_refresh_token: null,
                         app_client_id: clientId || config.LINEAR_CLIENT_ID,
                         app_client_secret: clientSecret || config.LINEAR_CLIENT_SECRET,
+                        tp_id: integrationId,
+                        appId: account?.apps[0].id,
+                        tp_customer_id: String(info.data.viewer?.id),
                     },
                     create: {
                         id: String(req.query.t_id),
@@ -181,8 +185,12 @@ authRouter.get('/oauth-callback', async (req, res) => {
                     },
                     update: {
                         tp_access_token: result.data?.access_token,
+                        tp_refresh_token: null,
                         app_client_id: clientId || config.CLICKUP_CLIENT_ID,
                         app_client_secret: clientSecret || config.CLICKUP_CLIENT_SECRET,
+                        tp_id: integrationId,
+                        appId: account?.apps[0].id,
+                        tp_customer_id: String(info.data?.user?.id),
                     },
                     create: {
                         id: String(req.query.t_id),
@@ -259,7 +267,6 @@ authRouter.get('/oauth-callback', async (req, res) => {
             const token = String(req.query.oauth_token);
             const verifier = String(req.query.oauth_verifier);
             const tokenSecret = await redis.get(`trello_dev_oauth_token_${req.query.oauth_token}`);
-            let info: any = {};
             try {
                 const { accessToken, accessTokenSecret }: { accessToken: string; accessTokenSecret: string } =
                     await new Promise((resolve, reject) => {
@@ -282,17 +289,23 @@ authRouter.get('/oauth-callback', async (req, res) => {
                     access_secret: accessTokenSecret,
                 };
                 logInfo('OAuth creds for Trello', access_creds);
-                oauth.getProtectedResource(
-                    'https://api.trello.com/1/members/me',
-                    'GET',
-                    accessToken,
-                    accessTokenSecret,
-                    (_error, data, _response) => {
-                        // @TODO error handling
-                        info = data;
-                        logInfo('OAuth token info', data);
-                    }
-                );
+                let info: any = await new Promise((resolve, reject) => {
+                    oauth.getProtectedResource(
+                        'https://api.trello.com/1/members/me',
+                        'GET',
+                        accessToken,
+                        accessTokenSecret,
+                        (error, data, _response) => {
+                            if (error) {
+                                reject(error);
+                            } else {
+                                resolve(data);
+                            }
+                            logInfo('OAuth token info', data);
+                        }
+                    );
+                });
+                info = JSON.parse(info);
 
                 await xprisma.connections.upsert({
                     where: {
@@ -300,8 +313,12 @@ authRouter.get('/oauth-callback', async (req, res) => {
                     },
                     update: {
                         tp_access_token: String(access_creds.access_token),
+                        tp_refresh_token: null,
                         app_client_id: clientId || config.TRELLO_CLIENT_ID,
                         app_client_secret: clientSecret || config.TRELLO_CLIENT_SECRET,
+                        tp_id: integrationId,
+                        appId: account?.apps[0].id,
+                        tp_customer_id: String(info.id),
                     },
                     create: {
                         id: String(req.query.t_id),
@@ -432,6 +449,11 @@ authRouter.get('/oauth-callback', async (req, res) => {
                     update: {
                         tp_access_token: result.data.access_token,
                         tp_refresh_token: result.data.refresh_token,
+                        app_client_id: clientId || config.JIRA_CLIENT_ID,
+                        app_client_secret: clientSecret || config.JIRA_CLIENT_SECRET,
+                        tp_id: integrationId,
+                        appId: account?.apps[0].id,
+                        tp_customer_id: accountId,
                     },
                 });
 


### PR DESCRIPTION
### Description

1. Multiple connections with same `t_id` & `tp_id` can exist provided they belong to different environment
2. Unique Constraints added `uniqueThirdPartyPerTenantPerEnvironment` & `uniqueThirdPartyPerEnvironment`

Fixes # (issue)

### Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?

-   [X] Check by establishing connection with same `tp_id` & `t_id` via different environments
-   Navigate to backend package `cd packages/backend`
-   Run `npx ts-node prisma/connectionIdMigrate.ts`

### Checklist:

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] I have commented my code, particularly in hard-to-understand areas
-   [X] My changes generate no new warnings
