### PR TITLE
fix: missing tp_account_url field in jira update connection

### DIFF
--- a/packages/backend/routes/v1/ticket/auth.ts
+++ b/packages/backend/routes/v1/ticket/auth.ts
@@ -454,6 +454,7 @@ authRouter.get('/oauth-callback', async (req, res) => {
                         tp_id: integrationId,
                         appId: account?.apps[0].id,
                         tp_customer_id: accountId,
+                        tp_account_url: jiraBaseUrl as string,
                     },
                 });
 


### PR DESCRIPTION
### Description

Added missing `tp_account_url` field in jira  update query.

### Type of change

-   [X] Bug fix (non-breaking change which fixes an issue)


### Checklist:

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings
