### PR TITLE
docs: add dependencies installation instruction to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,11 @@ Thanks for taking the interest in contributing ♥. We really appreciate any sup
 > **Note**
 > Please be sure that you can make a full production build before pushing code or creating PRs.
 
-You can build the project with:
+- Install the project dependencies by running:
+```bash
+yarn install
+```
+- Next, you can build the project with:
 
 ```bash
 yarn build


### PR DESCRIPTION
### Description
Add the description to install project dependencies to the `CONTRIBUTING.md` guide, which should be run before building the repository.

### Type of change
-   [x] This change requires a documentation update

### How Has This Been Tested?
The change works on the markdown preview feature on my text editor

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
