### PR TITLE
docs: show only external apis in api reference

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -54,6 +54,8 @@ navigation:
     - tab: api
       layout:
           - api: API Reference
+            audiences:
+                - external
     - tab: guides
       layout:
           - section: Integration Guides


### PR DESCRIPTION
### Description

show only external apis in api reference


### Type of change

-   [x] This change requires a documentation update

### How Has This Been Tested?

Documentation change only

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
