### PR TITLE
docs: ensure `additional` block is present in docs

### DIFF
--- a/fern/definition/common/unified.yml
+++ b/fern/definition/common/unified.yml
@@ -18,7 +18,7 @@ types:
                 type: unknown
                 docs: The last updated timestamp of the object.
             additional:
-                type: unknown
+                type: optional<unknown>
                 docs: Any fields that are not unified yet/non-unifiable come inside this `json` object.
     LeadWrite:
         properties:

--- a/fern/definition/crm/contact.yml
+++ b/fern/definition/crm/contact.yml
@@ -16,7 +16,12 @@ types:
             next: optional<string>
             previous: optional<string>
             results: list<unified.Contact>
-    CreateOrUpdateContactRequest: unified.ContactWrite
+    CreateOrUpdateContactRequest:
+        extends: unified.ContactWrite
+        properties:
+            additional:
+                type: unknown
+                docs: Any fields that are not unified yet/non-unifiable come inside this `json` object.
     CreateOrUpdateContactResponse:
         properties:
             status: types.ResponseStatus

--- a/fern/definition/crm/deal.yml
+++ b/fern/definition/crm/deal.yml
@@ -18,6 +18,10 @@ types:
             results: list<unified.Deal>
     CreateOrUpdateDealRequest:
         extends: unified.DealWrite
+        properties:
+            additional:
+                type: unknown
+                docs: Any fields that are not unified yet/non-unifiable come inside this `json` object.
     CreateOrUpdateDealResponse:
         properties:
             status: types.ResponseStatus

--- a/fern/definition/crm/event.yml
+++ b/fern/definition/crm/event.yml
@@ -19,6 +19,10 @@ types:
             results: list<unified.Event>
     CreateOrUpdateEventRequest:
         extends: unified.EventWrite
+        properties:
+            additional:
+                type: unknown
+                docs: Any fields that are not unified yet/non-unifiable come inside this `json` object.
     CreateOrUpdateEventResponse:
         properties:
             status: types.ResponseStatus

--- a/fern/definition/crm/lead.yml
+++ b/fern/definition/crm/lead.yml
@@ -18,6 +18,10 @@ types:
             results: list<unified.Lead>
     CreateOrUpdateLeadRequest:
         extends: unified.LeadWrite
+        properties:
+            additional:
+                type: unknown
+                docs: Any fields that are not unified yet/non-unifiable come inside this `json` object.
     CreateOrUpdateLeadResponse:
         properties:
             status: types.ResponseStatus

--- a/fern/definition/crm/note.yml
+++ b/fern/definition/crm/note.yml
@@ -18,6 +18,10 @@ types:
             results: list<unified.Note>
     CreateOrUpdateNoteRequest:
         extends: unified.NoteWrite
+        properties:
+            additional:
+                type: unknown
+                docs: Any fields that are not unified yet/non-unifiable come inside this `json` object.
     CreateOrUpdateNoteResponse:
         properties:
             status: types.ResponseStatus

--- a/fern/definition/crm/task.yml
+++ b/fern/definition/crm/task.yml
@@ -18,6 +18,10 @@ types:
             results: list<unified.Task>
     CreateOrUpdateTaskRequest:
         extends: unified.TaskWrite
+        properties:
+            additional:
+                type: unknown
+                docs: Any fields that are not unified yet/non-unifiable come inside this `json` object.
     CreateOrUpdateTaskResponse:
         properties:
             status: types.ResponseStatus

--- a/fern/definition/crm/user.yml
+++ b/fern/definition/crm/user.yml
@@ -18,6 +18,10 @@ types:
             results: list<unified.User>
     CreateOrUpdateUserRequest:
         extends: unified.UserWrite
+        properties:
+            additional:
+                type: unknown
+                docs: Any fields that are not unified yet/non-unifiable come inside this `json` object.
     CreateOrUpdateUserResponse:
         properties:
             status: types.ResponseStatus


### PR DESCRIPTION
### Description

ensure `additional` block is present in docs


### Type of change

-   [x] This change requires a documentation update

### How Has This Been Tested?

Documentation generated in preview mode 

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
