### PR TITLE
docs: fix broken links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@ Thanks for taking the interest in contributing ♥. We really appreciate any sup
 
 ## Before getting started
 
--   Before jumping into a PR be sure to search [existing PRs](https://github.com/revert/revert/pulls) or [issues](https://github.com/revert/revert/issues) for an open or closed item that relates to your submission.
--   Select an issue from [here](https://github.com/revert/revert/issues) or create a new one
+-   Before jumping into a PR be sure to search [existing PRs](https://github.com/revertinc/revert/pulls) or [issues](https://github.com/revertinc/revert/issues) for an open or closed item that relates to your submission.
+-   Select an issue from [here](https://github.com/revertinc/revert/issues) or create a new one
 -   Consider the results from the discussion in the issue
 
 ## Developing


### PR DESCRIPTION
### Description

Fix broken links pointing to `https://github.com/revert/revert` instead of  `https://github.com/revertinc/revert` in CONTRIBUTING.md

### Type of change

Please delete options that are not relevant.
-   [x] This change requires a documentation update

### How Has This Been Tested?

I can access the open the desired links instead of a `404` error.

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings

