### PR TITLE
feat: show object name in field mapping ui

### DIFF
--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -866,6 +866,28 @@ const createIntegrationBlock = function (self, integration) {
                 op.innerHTML = a.name;
                 return op;
             });
+            const objectHeading = createViewElement(
+                'div',
+                '',
+                transformStyle({
+                    fontWeight: '400',
+                    fontSize: '12px',
+                    color: '#4C505B',
+                }),
+                [],
+                'Object'
+            );
+            const objInput = createViewElement(
+                'div',
+                `sd-object-${fieldName}`,
+                transformStyle({
+                    fontWeight: '400',
+                    fontSize: '12px',
+                }),
+                [],
+                objectName
+            );
+            objInput.classList.add('input-style');
             const hiddenObject = createViewElement(
                 'div',
                 '',
@@ -938,7 +960,7 @@ const createIntegrationBlock = function (self, integration) {
                     marginBottom: '25px',
                     gap: '10px',
                 }),
-                [hiddenObject, mappableHeading, mappableInput, accountSpecificHeading, accountSpecificInput],
+                [objectHeading, objInput, mappableHeading, mappableInput, accountSpecificHeading, accountSpecificInput],
                 ''
             );
             return container;

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -888,17 +888,6 @@ const createIntegrationBlock = function (self, integration) {
                 objectName
             );
             objInput.classList.add('input-style');
-            const hiddenObject = createViewElement(
-                'div',
-                '',
-                transformStyle({
-                    visibility: 'hidden',
-                    height: '1px',
-                }),
-                [],
-                objectName
-            );
-            hiddenObject.classList.add('stdHiddenObj');
             const mappableHeading = createViewElement(
                 'div',
                 '',


### PR DESCRIPTION
### Description

Start showing object name in field mapping ui. 

<img width="448" alt="Screenshot 2024-03-08 at 9 34 06 AM" src="https://github.com/revertinc/revert/assets/7681067/fc90ce0e-5cc6-4510-8794-5961b3119744">


### Type of change

-   [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

-   [x] Tested locally (screenshot attached)

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
