### PR TITLE
fix: Return event details upon creation

### DIFF
--- a/packages/backend/services/crm/contact.ts
+++ b/packages/backend/services/crm/contact.ts
@@ -832,19 +832,26 @@ const contactService = new ContactService(
                                 authorization: `Zoho-oauthtoken ${thirdPartyToken}`,
                             },
                         });
-                        contacts = contacts.data.data;
-                        contacts = await Promise.all(
-                            contacts?.map(
-                                async (l: any) =>
-                                    await unifyObject<any, UnifiedContact>({
-                                        obj: l,
-                                        tpId: thirdPartyId,
-                                        objType,
-                                        tenantSchemaMappingId: connection.schema_mapping_id,
-                                        accountFieldMappingConfig: account.accountFieldMappingConfig,
-                                    })
-                            )
-                        );
+                        const isValidContactData =
+                            contacts.data && contacts.data.data !== undefined && Array.isArray(contacts.data.data);
+                        if (isValidContactData) {
+                            contacts = contacts?.data?.data;
+
+                            contacts = await Promise.all(
+                                contacts?.map(
+                                    async (l: any) =>
+                                        await unifyObject<any, UnifiedContact>({
+                                            obj: l,
+                                            tpId: thirdPartyId,
+                                            objType,
+                                            tenantSchemaMappingId: connection.schema_mapping_id,
+                                            accountFieldMappingConfig: account.accountFieldMappingConfig,
+                                        })
+                                )
+                            );
+                        } else {
+                            contacts = [];
+                        }
                         res.send({ status: 'ok', results: contacts });
                         break;
                     }

--- a/packages/backend/services/crm/event.ts
+++ b/packages/backend/services/crm/event.ts
@@ -469,7 +469,7 @@ const eventService = new EventService(
                         break;
                     }
                     case TP_ID.zohocrm: {
-                        await axios({
+                        const eventCreated: any = await axios({
                             method: 'post',
                             url: `https://www.zohoapis.com/crm/v3/Events`,
                             headers: {
@@ -477,7 +477,11 @@ const eventService = new EventService(
                             },
                             data: JSON.stringify(event),
                         });
-                        res.send({ status: 'ok', message: 'Zoho event created', result: event });
+                        res.send({
+                            status: 'ok',
+                            message: 'Zoho event created',
+                            result: { ...event, details: eventCreated.data.data[0].details },
+                        });
                         break;
                     }
                     case TP_ID.sfdc: {


### PR DESCRIPTION
### Description

- Return Zoho response upon creating a event instead of returning payload (Zoho create event).
- Assign contacts as an empty array if it is an empty string (for zoho SearchContacts)

### Type of change

Please delete options that are not relevant.

-   [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)


### Checklist:

-   [X] My code follows the style guidelines of this project
-   [X] My changes generate no new warnings
