### PR TITLE
fix: ensure default env is set on integration dashboard

### DIFF
--- a/packages/client/src/home/index.tsx
+++ b/packages/client/src/home/index.tsx
@@ -92,7 +92,7 @@ const Home = () => {
             .then((result) => {
                 setAccount(result?.account);
                 const environments: string[] = result?.account?.environments?.map((env) => env.env) || [];
-                setSelectedEnvironment(environments?.[0]);
+                setSelectedEnvironment(environments?.[0] || DEFAULT_ENV);
             })
             .catch((error) => {
                 Sentry.captureException(error);

--- a/packages/client/src/home/index.tsx
+++ b/packages/client/src/home/index.tsx
@@ -92,9 +92,7 @@ const Home = () => {
             .then((result) => {
                 setAccount(result?.account);
                 const environments: string[] = result?.account?.environments?.map((env) => env.env) || [];
-                if (!environments.includes(DEFAULT_ENV)) {
-                    setSelectedEnvironment(environments?.[0]);
-                }
+                setSelectedEnvironment(environments?.[0]);
             })
             .catch((error) => {
                 Sentry.captureException(error);

--- a/scripts/backend/backup_rds.sh
+++ b/scripts/backend/backup_rds.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-export TABLE=accounts; bash ./scripts/backup_table.sh
-export TABLE=environments ; bash scripts/backup_table.sh
-export TABLE=apps ; bash scripts/backup_table.sh
-export TABLE=users ; bash scripts/backup_table.sh
-export TABLE=waitlist ; bash scripts/backup_table.sh
-export TABLE=connections ; bash scripts/backup_table.sh
+export TABLE=accounts; bash ./backup_table.sh
+export TABLE=environments ; bash ./backup_table.sh
+export TABLE=apps ; bash ./backup_table.sh
+export TABLE=users ; bash ./backup_table.sh
+export TABLE=waitlist ; bash ./backup_table.sh
+export TABLE=connections ; bash ./backup_table.sh


### PR DESCRIPTION
### Description

hotfix: ensure default env is set on integration dashboard

### Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested with reproducing the bug where the screen became blank when trying to set OAuth creds for our users. 

![image (20)](https://github.com/revertinc/revert/assets/7681067/ca44106a-655d-4c5d-b837-0561da740ef4)


### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] Any dependent changes have been merged and published in downstream modules
