### PR TITLE
feat: add connection import endpoint

### DIFF
--- a/fern/definition/connection.yml
+++ b/fern/definition/connection.yml
@@ -47,6 +47,26 @@ types:
         enum:
             - SUCCESS
             - FAILED
+    ConnectionImport:
+        properties:
+            tp_id: types.TPID
+            tp_access_token: string
+            tp_refresh_token: string
+            tp_customer_id:
+                type: string
+                docs: The email id of the user who connected the app.
+            t_id: string
+            tp_account_url: optional<string>
+            app_client_id: string
+            app_client_secret: string
+            app_id: string
+
+    ImportConnectionsRequestBody:
+        properties:
+            connections: list<ConnectionImport>
+    ImportConnectionsResponse:
+        properties:
+            status: types.ResponseStatus
 
 service:
     base-path: ''
@@ -162,3 +182,20 @@ service:
             errors:
                 - errors.UnAuthorizedError
                 - errors.InternalServerError
+        importConnections:
+            docs: Import multiple connections for a specific environment. Use this to bulk import connections as a one-time exercise.
+            method: POST
+            path: /connection/import
+            request:
+                name: ImportConnectionsRequest
+                headers:
+                    x-revert-t-id:
+                        type: string
+                        docs: The unique customer id used when the customer linked their account.
+                body: ImportConnectionsRequestBody
+
+            response: ImportConnectionsResponse
+            errors:
+                - errors.UnAuthorizedError
+                - errors.InternalServerError
+                - errors.NotFoundError

--- a/fern/definition/connection.yml
+++ b/fern/definition/connection.yml
@@ -54,7 +54,7 @@ types:
             tp_refresh_token: string
             tp_customer_id:
                 type: string
-                docs: The email id of the user who connected the app.
+                docs: The emailId or a unique ID id of the user who connected the app.
             t_id: string
             tp_account_url: optional<string>
             app_client_id: string

--- a/packages/backend/oas/openapi.yml
+++ b/packages/backend/oas/openapi.yml
@@ -412,6 +412,52 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/commonBaseError'
+  /connection/import:
+    post:
+      description: >-
+        Import multiple connections for a specific environment. Use this to bulk
+        import connections as a one-time exercise.
+      operationId: connection_importConnections
+      tags:
+        - Connection
+      parameters:
+        - name: x-revert-t-id
+          in: header
+          description: The unique customer id used when the customer linked their account.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImportConnectionsResponse'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/commonBaseError'
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/commonBaseError'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/commonBaseError'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ImportConnectionsRequestBody'
   /crm/companies/{id}:
     get:
       description: Get details of a company
@@ -4264,6 +4310,57 @@ components:
       enum:
         - SUCCESS
         - FAILED
+    ConnectionImport:
+      title: ConnectionImport
+      type: object
+      properties:
+        tp_id:
+          $ref: '#/components/schemas/commonTPID'
+        tp_access_token:
+          type: string
+        tp_refresh_token:
+          type: string
+        tp_customer_id:
+          type: string
+          description: The email id of the user who connected the app.
+        t_id:
+          type: string
+        tp_account_url:
+          type: string
+          nullable: true
+        app_client_id:
+          type: string
+        app_client_secret:
+          type: string
+        app_id:
+          type: string
+      required:
+        - tp_id
+        - tp_access_token
+        - tp_refresh_token
+        - tp_customer_id
+        - t_id
+        - app_client_id
+        - app_client_secret
+        - app_id
+    ImportConnectionsRequestBody:
+      title: ImportConnectionsRequestBody
+      type: object
+      properties:
+        connections:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConnectionImport'
+      required:
+        - connections
+    ImportConnectionsResponse:
+      title: ImportConnectionsResponse
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/commonResponseStatus'
+      required:
+        - status
     crmGetCompanyResponse:
       title: crmGetCompanyResponse
       type: object

--- a/packages/backend/routes/v1/crm/authHandlers/hubspot.ts
+++ b/packages/backend/routes/v1/crm/authHandlers/hubspot.ts
@@ -65,7 +65,7 @@ class HubspotAuthHandler extends BaseOAuthHandler {
                     tp_access_token: result.data.access_token,
                     tp_refresh_token: result.data.refresh_token,
                     app_client_id: clientId || config.HUBSPOT_CLIENT_ID,
-                    app_client_secret: clientSecret || config.HUBSPOT_CLIENT_SECRET, // TODO: Fix in other platforms.
+                    app_client_secret: clientSecret || config.HUBSPOT_CLIENT_SECRET,
                     tp_customer_id: info.data.user,
                     owner_account_public_token: revertPublicKey,
                     appId: account?.apps[0].id,

--- a/packages/backend/services/connection.ts
+++ b/packages/backend/services/connection.ts
@@ -3,8 +3,9 @@ import prisma, { xprisma } from '../prisma/client';
 import config from '../config';
 import { logError } from '../helpers/logger';
 import { v4 as uuidv4 } from 'uuid';
-import { NotFoundError, UnAuthorizedError } from '../generated/typescript/api/resources/common/resources';
+import { Connection, NotFoundError, UnAuthorizedError } from '../generated/typescript/api/resources/common/resources';
 import { sendConnectionDeletedEvent } from '../helpers/webhooks/connection';
+import { ConnectionImport } from 'generated/typescript/api';
 
 const connectionService = new ConnectionService({
     async getConnection(req, res) {
@@ -68,6 +69,75 @@ const connectionService = new ConnectionService({
             res.send(connections);
         } else {
             throw new NotFoundError({ error: 'Connections not found!' });
+        }
+    },
+    async importConnections(req, res) {
+        const { 'x-revert-api-token': token } = req.headers;
+        if (!token) {
+            throw new UnAuthorizedError({ error: 'Api unauthorized' });
+        }
+        try {
+            const environment = await prisma.environments.findFirst({
+                where: {
+                    private_token: String(token),
+                },
+            });
+            if (!environment) {
+                throw new UnAuthorizedError({ error: 'Api unauthorized' });
+            }
+            const connectionsData = req.body.connections;
+            const createdConnections = await Promise.all(
+                connectionsData.map(async (connection) => {
+                    return await xprisma.connections.upsert({
+                        where: {
+                            id: connection.t_id,
+                        },
+                        update: {
+                            id: connection.t_id,
+                            t_id: connection.t_id,
+                            tp_id: connection.tp_id,
+                            tp_access_token: connection.tp_access_token,
+                            tp_refresh_token: connection.tp_refresh_token,
+                            app_client_id: connection.app_client_id,
+                            app_client_secret: connection.app_client_secret,
+                            tp_customer_id: connection.tp_customer_id,
+                            owner_account_public_token: environment.public_token,
+                            appId: connection.app_id,
+                            tp_account_url: connection.tp_account_url,
+                            environmentId: environment?.id,
+                        },
+                        create: {
+                            id: connection.t_id,
+                            t_id: connection.t_id,
+                            tp_id: connection.tp_id,
+                            tp_access_token: connection.tp_access_token,
+                            tp_refresh_token: connection.tp_refresh_token,
+                            app_client_id: connection.app_client_id,
+                            app_client_secret: connection.app_client_secret,
+                            tp_customer_id: connection.tp_customer_id,
+                            owner_account_public_token: environment.public_token,
+                            appId: connection.app_id,
+                            tp_account_url: connection.tp_account_url,
+                            environmentId: environment?.id,
+                        },
+                    });
+                })
+            );
+
+            if (createdConnections) {
+                // TODO: Should webhooks get fired for bulk import of connections?
+                // const svixAppId = environment?.accountId!;
+                // createdConnections.forEach((c) => sendConnectionDeletedEvent(svixAppId, c));
+                res.send({ status: 'ok' });
+            } else {
+                throw new NotFoundError({ error: 'Connections not imported!' });
+            }
+        } catch (error: any) {
+            logError(error);
+            console.error(error);
+            res.send({
+                status: 'error',
+            });
         }
     },
     async deleteConnection(req, res) {

--- a/packages/backend/services/connection.ts
+++ b/packages/backend/services/connection.ts
@@ -3,9 +3,8 @@ import prisma, { xprisma } from '../prisma/client';
 import config from '../config';
 import { logError } from '../helpers/logger';
 import { v4 as uuidv4 } from 'uuid';
-import { Connection, NotFoundError, UnAuthorizedError } from '../generated/typescript/api/resources/common/resources';
+import { NotFoundError, UnAuthorizedError } from '../generated/typescript/api/resources/common/resources';
 import { sendConnectionDeletedEvent } from '../helpers/webhooks/connection';
-import { ConnectionImport } from 'generated/typescript/api';
 
 const connectionService = new ConnectionService({
     async getConnection(req, res) {

--- a/packages/client/src/home/editCredentials.tsx
+++ b/packages/client/src/home/editCredentials.tsx
@@ -126,7 +126,10 @@ const EditCredentials: React.FC<{
             <Row>
                 <span style={{ display: 'flex', flexDirection: 'column' }}>
                     <span className="font-bold">Use default revert app</span>
-                    <span style={{ fontSize: '14px' }}>(uncheck to use your own app credentials)</span>
+                    <span style={{ fontSize: '14px', marginBottom: 20 }}>
+                        (uncheck to use your own app credentials)
+                    </span>
+                    <span className="text-xs align-right font-bold mb-4"> AppId: {app.id}</span>
                 </span>
                 <Switch
                     style={{ color: '#fff' }}


### PR DESCRIPTION
### Description

1. Adds a connection import endpoint that allows users to move into Revert from any other integration provider or from in-house management of OAuth tokens. 
2. We also show the `appId` on the integration dashboard

### Type of change

-   [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Tested importing tokens for new connections 

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
