### PR TITLE
feat: remaining Support Pagination in CRM search API endpoints

### DIFF
--- a/packages/backend/services/crm/company.ts
+++ b/packages/backend/services/crm/company.ts
@@ -700,13 +700,18 @@ const companyService = new CompanyService(
                         break;
                     }
                     case TP_ID.zohocrm: {
+                        const pagingString = `${pageSize ? `&per_page=${pageSize}` : ''}${
+                            cursor ? `&page_token=${cursor}` : ''
+                        }`;
                         let companies: any = await axios({
                             method: 'get',
-                            url: `https://www.zohoapis.com/crm/v3/Accounts/search?criteria=${searchCriteria}`,
+                            url: `https://www.zohoapis.com/crm/v3/Accounts/search?criteria=${searchCriteria}${pagingString}`,
                             headers: {
                                 authorization: `Zoho-oauthtoken ${thirdPartyToken}`,
                             },
                         });
+                        const nextCursor = companies.data?.info?.next_page_token || undefined;
+                        const prevCursor = companies.data?.info?.previous_page_token || undefined;
                         companies = companies.data.data;
                         companies = await Promise.all(
                             companies?.map(
@@ -720,7 +725,7 @@ const companyService = new CompanyService(
                                     })
                             )
                         );
-                        res.send({ status: 'ok', results: companies });
+                        res.send({ status: 'ok', next: nextCursor, previous: prevCursor, results: companies });
                         break;
                     }
                     case TP_ID.sfdc: {

--- a/packages/backend/services/crm/company.ts
+++ b/packages/backend/services/crm/company.ts
@@ -804,15 +804,16 @@ const companyService = new CompanyService(
                         if (searchCriteria) {
                             searchString += fields ? `&$filter=${searchCriteria}` : `$filter=${searchCriteria}`;
                         }
-
+                        const pagingString = cursor ? encodeURI(cursor).split('?')[1] : '';
                         const result = await axios({
                             method: 'get',
-                            url: `${connection.tp_account_url}/api/data/v9.2/accounts?${searchString}`,
+                            url: `${connection.tp_account_url}/api/data/v9.2/accounts?${searchString}${pagingString}`,
                             headers: {
                                 Authorization: `Bearer ${thirdPartyToken}`,
                                 'OData-MaxVersion': '4.0',
                                 'OData-Version': '4.0',
                                 Accept: 'application/json',
+                                Prefer: pageSize ? `odata.maxpagesize=${pageSize}` : '',
                             },
                         });
 
@@ -829,7 +830,12 @@ const companyService = new CompanyService(
                             )
                         );
 
-                        res.send({ status: 'ok', results: unifiedCompanies });
+                        res.send({
+                            status: 'ok',
+                            next: result.data['@odata.nextLink'],
+                            previous: undefined,
+                            results: unifiedCompanies,
+                        });
                         break;
                     }
                     default: {

--- a/packages/backend/services/crm/contact.ts
+++ b/packages/backend/services/crm/contact.ts
@@ -232,6 +232,7 @@ const contactService = new ContactService(
                             },
                         });
                         const nextCursor = contacts.data?.paging?.next?.after || undefined;
+
                         contacts = contacts.data.results as any[];
                         contacts = await Promise.all(
                             contacts?.map(
@@ -825,17 +826,25 @@ const contactService = new ContactService(
                         break;
                     }
                     case TP_ID.zohocrm: {
+                        const pagingString = `${pageSize ? `&per_page=${pageSize}` : ''}${
+                            cursor ? `&page_token=${cursor}` : ''
+                        }`;
                         let contacts: any = await axios({
                             method: 'get',
-                            url: `https://www.zohoapis.com/crm/v3/Contacts/search?criteria=${searchCriteria}`,
+                            url: `https://www.zohoapis.com/crm/v3/Contacts/search?criteria=${searchCriteria}${pagingString}`,
                             headers: {
                                 authorization: `Zoho-oauthtoken ${thirdPartyToken}`,
                             },
                         });
+
+                        let nextCursor;
+                        let prevCursor;
                         const isValidContactData =
                             contacts.data && contacts.data.data !== undefined && Array.isArray(contacts.data.data);
                         if (isValidContactData) {
                             contacts = contacts?.data?.data;
+                            nextCursor = contacts.data?.info?.next_page_token || undefined;
+                            prevCursor = contacts.data?.info?.previous_page_token || undefined;
 
                             contacts = await Promise.all(
                                 contacts?.map(
@@ -852,7 +861,7 @@ const contactService = new ContactService(
                         } else {
                             contacts = [];
                         }
-                        res.send({ status: 'ok', results: contacts });
+                        res.send({ status: 'ok', next: nextCursor, previous: prevCursor, results: contacts });
                         break;
                     }
                     case TP_ID.sfdc: {

--- a/packages/backend/services/crm/contact.ts
+++ b/packages/backend/services/crm/contact.ts
@@ -954,8 +954,16 @@ const contactService = new ContactService(
                                 'Content-Type': 'application/json',
                                 Authorization: `Bearer ${thirdPartyToken}`,
                             },
-                            data: { ...searchCriteria, _fields: { contact: fields } },
+                            data: {
+                                ...searchCriteria,
+                                _fields: { contact: fields },
+                                _limit: pageSize || 100,
+                                cursor: cursor,
+                            },
                         });
+
+                        const nextCursor = response.data?.cursor || undefined;
+                        const prevCursor = undefined;
 
                         const contacts = await Promise.all(
                             response.data.data.map(
@@ -970,7 +978,7 @@ const contactService = new ContactService(
                             )
                         );
 
-                        res.send({ status: 'ok', results: contacts });
+                        res.send({ status: 'ok', next: nextCursor, previous: prevCursor, results: contacts });
                         break;
                     }
                     case TP_ID.ms_dynamics_365_sales: {

--- a/packages/backend/services/crm/contact.ts
+++ b/packages/backend/services/crm/contact.ts
@@ -986,15 +986,16 @@ const contactService = new ContactService(
                         if (searchCriteria) {
                             searchString += fields ? `&$filter=${searchCriteria}` : `$filter=${searchCriteria}`;
                         }
-
+                        const pagingString = cursor ? encodeURI(cursor).split('?')[1] : '';
                         const result = await axios({
                             method: 'get',
-                            url: `${connection.tp_account_url}/api/data/v9.2/contacts?${searchString}`,
+                            url: `${connection.tp_account_url}/api/data/v9.2/contacts?${searchString}${pagingString}`,
                             headers: {
                                 Authorization: `Bearer ${thirdPartyToken}`,
                                 'OData-MaxVersion': '4.0',
                                 'OData-Version': '4.0',
                                 Accept: 'application/json',
+                                Prefer: pageSize ? `odata.maxpagesize=${pageSize}` : '',
                             },
                         });
 
@@ -1011,7 +1012,12 @@ const contactService = new ContactService(
                             )
                         );
 
-                        res.send({ status: 'ok', results: unifiedContacts });
+                        res.send({
+                            status: 'ok',
+                            next: result.data['@odata.nextLink'],
+                            previous: undefined,
+                            results: unifiedContacts,
+                        });
                         break;
                     }
                     default: {

--- a/packages/backend/services/crm/deal.ts
+++ b/packages/backend/services/crm/deal.ts
@@ -914,15 +914,16 @@ const dealService = new DealService(
                         if (searchCriteria) {
                             searchString += fields ? `&$filter=${searchCriteria}` : `$filter=${searchCriteria}`;
                         }
-
+                        const pagingString = cursor ? encodeURI(cursor).split('?')[1] : '';
                         const result = await axios({
                             method: 'get',
-                            url: `${connection.tp_account_url}/api/data/v9.2/opportunities?${searchString}`,
+                            url: `${connection.tp_account_url}/api/data/v9.2/opportunities?${searchString}${pagingString}`,
                             headers: {
                                 Authorization: `Bearer ${thirdPartyToken}`,
                                 'OData-MaxVersion': '4.0',
                                 'OData-Version': '4.0',
                                 Accept: 'application/json',
+                                Prefer: pageSize ? `odata.maxpagesize=${pageSize}` : '',
                             },
                         });
 
@@ -939,7 +940,12 @@ const dealService = new DealService(
                             )
                         );
 
-                        res.send({ status: 'ok', results: unifiedDeals });
+                        res.send({
+                            status: 'ok',
+                            next: result.data['@odata.nextLink'],
+                            previous: undefined,
+                            results: unifiedDeals,
+                        });
                         break;
                     }
                     default: {

--- a/packages/backend/services/crm/deal.ts
+++ b/packages/backend/services/crm/deal.ts
@@ -812,13 +812,19 @@ const dealService = new DealService(
                         break;
                     }
                     case TP_ID.zohocrm: {
+                        const pagingString = `${pageSize ? `&per_page=${pageSize}` : ''}${
+                            cursor ? `&page_token=${cursor}` : ''
+                        }`;
                         let deals: any = await axios({
                             method: 'get',
-                            url: `https://www.zohoapis.com/crm/v3/deals/search?criteria=${searchCriteria}`,
+                            url: `https://www.zohoapis.com/crm/v3/deals/search?criteria=${searchCriteria}${pagingString}`,
                             headers: {
                                 authorization: `Zoho-oauthtoken ${thirdPartyToken}`,
                             },
                         });
+
+                        const nextCursor = deals.data?.info?.next_page_token || undefined;
+                        const prevCursor = deals.data?.info?.previous_page_token || undefined;
                         deals = deals.data.data;
                         deals = await Promise.all(
                             deals?.map(
@@ -832,7 +838,7 @@ const dealService = new DealService(
                                     })
                             )
                         );
-                        res.send({ status: 'ok', results: deals });
+                        res.send({ status: 'ok', next: nextCursor, previous: prevCursor, results: deals });
                         break;
                     }
                     case TP_ID.sfdc: {

--- a/packages/backend/services/crm/event.ts
+++ b/packages/backend/services/crm/event.ts
@@ -725,13 +725,18 @@ const eventService = new EventService(
                         break;
                     }
                     case TP_ID.zohocrm: {
+                        const pagingString = `${pageSize ? `&per_page=${pageSize}` : ''}${
+                            cursor ? `&page_token=${cursor}` : ''
+                        }`;
                         let events: any = await axios({
                             method: 'get',
-                            url: `https://www.zohoapis.com/crm/v3/Events/search?criteria=${searchCriteria}`,
+                            url: `https://www.zohoapis.com/crm/v3/Events/search?criteria=${searchCriteria}${pagingString}`,
                             headers: {
                                 authorization: `Zoho-oauthtoken ${thirdPartyToken}`,
                             },
                         });
+                        const nextCursor = events.data?.info?.next_page_token || undefined;
+                        const prevCursor = events.data?.info?.previous_page_token || undefined;
                         events = events.data.data;
                         events = await Promise.all(
                             events?.map(
@@ -745,7 +750,7 @@ const eventService = new EventService(
                                     })
                             )
                         );
-                        res.send({ status: 'ok', results: events });
+                        res.send({ status: 'ok', next: nextCursor, previous: prevCursor, results: events });
                         break;
                     }
                     case TP_ID.sfdc: {

--- a/packages/backend/services/crm/event.ts
+++ b/packages/backend/services/crm/event.ts
@@ -793,15 +793,16 @@ const eventService = new EventService(
                         if (searchCriteria) {
                             searchString += fields ? `&$filter=${searchCriteria}` : `$filter=${searchCriteria}`;
                         }
-
+                        const pagingString = cursor ? encodeURI(cursor).split('?')[1] : '';
                         const result = await axios({
                             method: 'get',
-                            url: `${connection.tp_account_url}/api/data/v9.2/appointments?${searchString}`,
+                            url: `${connection.tp_account_url}/api/data/v9.2/appointments?${searchString}${pagingString}`,
                             headers: {
                                 Authorization: `Bearer ${thirdPartyToken}`,
                                 'OData-MaxVersion': '4.0',
                                 'OData-Version': '4.0',
                                 Accept: 'application/json',
+                                Prefer: pageSize ? `odata.maxpagesize=${pageSize}` : '',
                             },
                         });
 
@@ -818,7 +819,12 @@ const eventService = new EventService(
                             )
                         );
 
-                        res.send({ status: 'ok', results: unifiedEvents });
+                        res.send({
+                            status: 'ok',
+                            next: result.data['@odata.nextLink'],
+                            previous: undefined,
+                            results: unifiedEvents,
+                        });
                         break;
                     }
                     default: {

--- a/packages/backend/services/crm/lead.ts
+++ b/packages/backend/services/crm/lead.ts
@@ -786,13 +786,18 @@ const leadService = new LeadService(
                         break;
                     }
                     case TP_ID.zohocrm: {
+                        const pagingString = `${pageSize ? `&per_page=${pageSize}` : ''}${
+                            cursor ? `&page_token=${cursor}` : ''
+                        }`;
                         let leads: any = await axios({
                             method: 'get',
-                            url: `https://www.zohoapis.com/crm/v3/Leads/search?criteria=${searchCriteria}`,
+                            url: `https://www.zohoapis.com/crm/v3/Leads/search?criteria=${searchCriteria}${pagingString}`,
                             headers: {
                                 authorization: `Zoho-oauthtoken ${thirdPartyToken}`,
                             },
                         });
+                        const nextCursor = leads.data?.info?.next_page_token || undefined;
+                        const prevCursor = leads.data?.info?.previous_page_token || undefined;
                         leads = leads.data.data;
                         leads = await Promise.all(
                             leads?.map(
@@ -806,7 +811,7 @@ const leadService = new LeadService(
                                     })
                             )
                         );
-                        res.send({ status: 'ok', results: leads });
+                        res.send({ status: 'ok', next: nextCursor, previous: prevCursor, results: leads });
                         break;
                     }
                     case TP_ID.sfdc: {

--- a/packages/backend/services/crm/lead.ts
+++ b/packages/backend/services/crm/lead.ts
@@ -840,6 +840,9 @@ const leadService = new LeadService(
                         break;
                     }
                     case TP_ID.pipedrive: {
+                        const pagingString = `${pageSize ? `&limit=${pageSize}` : ''}${
+                            cursor ? `&start=${cursor}` : ''
+                        }`;
                         const instanceUrl = connection.tp_account_url;
                         const result = await axios.get<
                             {
@@ -848,13 +851,16 @@ const leadService = new LeadService(
                         >(
                             `${instanceUrl}/v1/leads/search?term=${searchCriteria}${
                                 formattedFields.length ? `&fields=${formattedFields.join(',')}` : ''
-                            }`,
+                            }${pagingString}`,
                             {
                                 headers: {
                                     Authorization: `Bearer ${thirdPartyToken}`,
                                 },
                             }
                         );
+
+                        const nextCursor = String(result.data?.additional_data?.pagination.next_start) || undefined;
+                        const prevCursor = undefined;
                         // this api has person and organization auto populated
                         const leads = result.data.data.items.map((item) => item.item);
                         const unifiedLeads = await Promise.all(
@@ -869,7 +875,7 @@ const leadService = new LeadService(
                                     })
                             )
                         );
-                        res.send({ status: 'ok', results: unifiedLeads });
+                        res.send({ status: 'ok', next: nextCursor, previous: prevCursor, results: unifiedLeads });
                         break;
                     }
                     case TP_ID.ms_dynamics_365_sales: {

--- a/packages/backend/services/crm/lead.ts
+++ b/packages/backend/services/crm/lead.ts
@@ -891,15 +891,17 @@ const leadService = new LeadService(
                         if (searchCriteria) {
                             searchString += fields ? `&$filter=${searchCriteria}` : `$filter=${searchCriteria}`;
                         }
+                        const pagingString = cursor ? encodeURI(cursor).split('?')[1] : '';
 
                         const result = await axios({
                             method: 'get',
-                            url: `${connection.tp_account_url}/api/data/v9.2/leads?${searchString}`,
+                            url: `${connection.tp_account_url}/api/data/v9.2/leads?${searchString}${pagingString}`,
                             headers: {
                                 Authorization: `Bearer ${thirdPartyToken}`,
                                 'OData-MaxVersion': '4.0',
                                 'OData-Version': '4.0',
                                 Accept: 'application/json',
+                                Prefer: pageSize ? `odata.maxpagesize=${pageSize}` : '',
                             },
                         });
 
@@ -916,7 +918,12 @@ const leadService = new LeadService(
                             )
                         );
 
-                        res.send({ status: 'ok', results: unifiedLeads });
+                        res.send({
+                            status: 'ok',
+                            next: result.data['@odata.nextLink'],
+                            previous: undefined,
+                            results: unifiedLeads,
+                        });
                         break;
                     }
                     default: {

--- a/packages/backend/services/crm/note.ts
+++ b/packages/backend/services/crm/note.ts
@@ -717,13 +717,18 @@ const noteService = new NoteService(
                         break;
                     }
                     case TP_ID.zohocrm: {
+                        const pagingString = `${pageSize ? `&per_page=${pageSize}` : ''}${
+                            cursor ? `&page_token=${cursor}` : ''
+                        }`;
                         let notes: any = await axios({
                             method: 'get',
-                            url: `https://www.zohoapis.com/crm/v3/notes/search?criteria=${searchCriteria}`,
+                            url: `https://www.zohoapis.com/crm/v3/notes/search?criteria=${searchCriteria}${pagingString}`,
                             headers: {
                                 authorization: `Zoho-oauthtoken ${thirdPartyToken}`,
                             },
                         });
+                        const nextCursor = notes.data?.info?.next_page_token || undefined;
+                        const prevCursor = notes.data?.info?.previous_page_token || undefined;
                         notes = notes.data.data;
                         notes = await Promise.all(
                             notes?.map(
@@ -737,7 +742,7 @@ const noteService = new NoteService(
                                     })
                             )
                         );
-                        res.send({ status: 'ok', results: notes });
+                        res.send({ status: 'ok', next: nextCursor, previous: prevCursor, results: notes });
                         break;
                     }
                     case TP_ID.sfdc: {

--- a/packages/backend/services/crm/note.ts
+++ b/packages/backend/services/crm/note.ts
@@ -813,15 +813,16 @@ const noteService = new NoteService(
                         if (searchCriteria) {
                             searchString += fields ? `&$filter=${searchCriteria}` : `$filter=${searchCriteria}`;
                         }
-
+                        const pagingString = cursor ? encodeURI(cursor).split('?')[1] : '';
                         const result = await axios({
                             method: 'get',
-                            url: `${connection.tp_account_url}/api/data/v9.2/annotations?${searchString}`,
+                            url: `${connection.tp_account_url}/api/data/v9.2/annotations?${searchString}${pagingString}`,
                             headers: {
                                 Authorization: `Bearer ${thirdPartyToken}`,
                                 'OData-MaxVersion': '4.0',
                                 'OData-Version': '4.0',
                                 Accept: 'application/json',
+                                Prefer: pageSize ? `odata.maxpagesize=${pageSize}` : '',
                             },
                         });
 
@@ -838,7 +839,12 @@ const noteService = new NoteService(
                             )
                         );
 
-                        res.send({ status: 'ok', results: unifiedNotes });
+                        res.send({
+                            status: 'ok',
+                            next: result.data['@odata.nextLink'],
+                            previous: undefined,
+                            results: unifiedNotes,
+                        });
                         break;
                     }
                     default: {

--- a/packages/backend/services/crm/task.ts
+++ b/packages/backend/services/crm/task.ts
@@ -757,13 +757,18 @@ const taskService = new TaskService(
                         break;
                     }
                     case TP_ID.zohocrm: {
+                        const pagingString = `${pageSize ? `&per_page=${pageSize}` : ''}${
+                            cursor ? `&page_token=${cursor}` : ''
+                        }`;
                         let tasks: any = await axios({
                             method: 'get',
-                            url: `https://www.zohoapis.com/crm/v3/Tasks/search?criteria=${searchCriteria}`,
+                            url: `https://www.zohoapis.com/crm/v3/Tasks/search?criteria=${searchCriteria}${pagingString}`,
                             headers: {
                                 authorization: `Zoho-oauthtoken ${thirdPartyToken}`,
                             },
                         });
+                        const nextCursor = tasks.data?.info?.next_page_token || undefined;
+                        const prevCursor = tasks.data?.info?.previous_page_token || undefined;
                         tasks = tasks.data.data;
                         tasks = await Promise.all(
                             tasks?.map(
@@ -777,7 +782,7 @@ const taskService = new TaskService(
                                     })
                             )
                         );
-                        res.send({ status: 'ok', results: tasks });
+                        res.send({ status: 'ok', next: nextCursor, previous: prevCursor, results: tasks });
                         break;
                     }
                     case TP_ID.sfdc: {

--- a/packages/backend/services/crm/task.ts
+++ b/packages/backend/services/crm/task.ts
@@ -827,15 +827,17 @@ const taskService = new TaskService(
                         if (searchCriteria) {
                             searchString += fields ? `&$filter=${searchCriteria}` : `$filter=${searchCriteria}`;
                         }
+                        const pagingString = cursor ? encodeURI(cursor).split('?')[1] : '';
 
                         const result = await axios({
                             method: 'get',
-                            url: `${connection.tp_account_url}/api/data/v9.2/tasks?${searchString}`,
+                            url: `${connection.tp_account_url}/api/data/v9.2/tasks?${searchString}${pagingString}`,
                             headers: {
                                 Authorization: `Bearer ${thirdPartyToken}`,
                                 'OData-MaxVersion': '4.0',
                                 'OData-Version': '4.0',
                                 Accept: 'application/json',
+                                Prefer: pageSize ? `odata.maxpagesize=${pageSize}` : '',
                             },
                         });
 
@@ -852,7 +854,12 @@ const taskService = new TaskService(
                             )
                         );
 
-                        res.send({ status: 'ok', results: unifiedTasks });
+                        res.send({
+                            status: 'ok',
+                            next: result.data['@odata.nextLink'],
+                            previous: undefined,
+                            results: unifiedTasks,
+                        });
                         break;
                     }
                     default: {


### PR DESCRIPTION
### Description

fixes #546 

Adds pagination support for Zoho CRM, Close crm, ms dynamics 365 sales, pipedrive.
Pagination has been added to the endpoints that have search api in the above mentioned crms.

Remaining: Salesforce (a discussion is required on how to proceed towards pagination in this integration). (Edit: pagination will be handled by the users themselves for the salesforce crm).

### Type of change




-   [x] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

### How Has This Been Tested?

via postman

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
