### PR TITLE
feat: only create apps that are needed by a developer

### DIFF
--- a/fern/definition/internal/account.yml
+++ b/fern/definition/internal/account.yml
@@ -50,3 +50,20 @@ service:
                 - errors.UnAuthorizedError
                 - errors.InternalServerError
                 - errors.NotFoundError
+        createRevertAppForAccount:
+            docs: create Revert App for Account
+            method: POST
+            path: /apps
+            request: 
+                name: CreateRevertAppForAccount
+                body: 
+                    properties: 
+                        userId: string
+                        tpId: types.TPID
+                        environment: string
+            response: GetAccountDetailsResponse
+            errors: 
+                - errors.UnAuthorizedError
+                - errors.InternalServerError
+                        
+

--- a/packages/backend/oas/openapi.yml
+++ b/packages/backend/oas/openapi.yml
@@ -2745,6 +2745,49 @@ paths:
                 - tpId
                 - isRevertApp
                 - appId
+  /internal/account/apps:
+    post:
+      description: create Revert App for Account
+      operationId: internal_account_createRevertAppForAccount
+      tags:
+        - InternalAccount
+      parameters: []
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/internalGetAccountDetailsResponse'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/commonBaseError'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/commonBaseError'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userId:
+                  type: string
+                tpId:
+                  $ref: '#/components/schemas/commonTPID'
+                environment:
+                  type: string
+              required:
+                - userId
+                - tpId
+                - environment
   /internal/analytics:
     post:
       description: Get Analytics of your revert account

--- a/packages/backend/routes/index.ts
+++ b/packages/backend/routes/index.ts
@@ -5,7 +5,7 @@ import cors from 'cors';
 
 import { createSession } from 'better-sse';
 import pubsub, { IntegrationStatusSseMessage, PUBSUB_CHANNELS } from '../redis/client/pubsub';
-import { logDebug } from '../helpers/logger';
+import { logDebug, logInfo } from '../helpers/logger';
 
 import crmRouter from './v1/crm';
 import config from '../config';
@@ -116,6 +116,7 @@ router.post('/slack-alert', async (req, res) => {
 });
 
 router.post('/clerk/webhook', async (req, res) => {
+    logInfo(req.body);
     if (req.body) {
         let webhookData = req.body.data;
         let webhookEventType = req.body.type;

--- a/packages/backend/routes/index.ts
+++ b/packages/backend/routes/index.ts
@@ -116,7 +116,6 @@ router.post('/slack-alert', async (req, res) => {
 });
 
 router.post('/clerk/webhook', async (req, res) => {
-    logInfo(req.body);
     if (req.body) {
         let webhookData = req.body.data;
         let webhookEventType = req.body.type;

--- a/packages/backend/routes/index.ts
+++ b/packages/backend/routes/index.ts
@@ -5,7 +5,7 @@ import cors from 'cors';
 
 import { createSession } from 'better-sse';
 import pubsub, { IntegrationStatusSseMessage, PUBSUB_CHANNELS } from '../redis/client/pubsub';
-import { logDebug, logInfo } from '../helpers/logger';
+import { logDebug } from '../helpers/logger';
 
 import crmRouter from './v1/crm';
 import config from '../config';

--- a/packages/backend/services/Internal/account.ts
+++ b/packages/backend/services/Internal/account.ts
@@ -68,7 +68,7 @@ const accountService = new AccountService({
                 throw new NotFoundError({ error: 'Could not get the account for user' });
             }
 
-            const isCreated = await AppService.createRevertAppForAccount({ userId, tpId, environment });
+            const isCreated = await AppService.createRevertAppForAccount({ accountId: result.account.id as string, tpId, environment });
 
             if (isCreated?.error) {
                 throw new InternalServerError({ error: 'Internal Server Error' });

--- a/packages/backend/services/Internal/account.ts
+++ b/packages/backend/services/Internal/account.ts
@@ -2,6 +2,7 @@ import { logError } from '../../helpers/logger';
 import { AccountService } from '../../generated/typescript/api/resources/internal/resources/account/service/AccountService';
 import { InternalServerError, NotFoundError, UnAuthorizedError } from '../../generated/typescript/api/resources/common';
 import AuthService from '../auth';
+import AppService from '../app';
 import prisma from '../../prisma/client';
 
 const accountService = new AccountService({
@@ -55,6 +56,28 @@ const accountService = new AccountService({
         } catch (error: any) {
             logError(error);
             console.error('Could not get account for user', error);
+            throw new InternalServerError({ error: 'Internal server error' });
+        }
+    },
+    async createRevertAppForAccount(req, res) {
+        try {
+            const { userId, tpId, environment } = req.body;
+            const result = await AuthService.getAccountForUser(userId);
+
+            if (result?.error) {
+                throw new NotFoundError({ error: 'Could not get the account for user' });
+            }
+
+            const isCreated = await AppService.createRevertAppForAccount({ userId, tpId, environment });
+
+            if (isCreated?.error) {
+                throw new InternalServerError({ error: 'Internal Server Error' });
+            }
+
+            const finalResult = await AuthService.getAccountForUser(userId);
+            res.send({ ...finalResult });
+        } catch (error: any) {
+            logError(error);
             throw new InternalServerError({ error: 'Internal server error' });
         }
     },

--- a/packages/backend/services/app.ts
+++ b/packages/backend/services/app.ts
@@ -3,23 +3,19 @@ import prisma from '../prisma/client';
 
 class AppService {
     async createRevertAppForAccount({
-        userId,
+        accountId,
         tpId,
         environment,
     }: {
-        userId: string;
+        accountId: string;
         tpId: TP_ID;
         environment: string;
     }): Promise<any> {
-        const id = `${tpId}_${userId}_${environment}`;
-        const environmentId = `${userId}_${environment}`;
+        const id = `${tpId}_${accountId}_${environment}`;
+        const environmentId = `${accountId}_${environment}`;
         try {
-            const createdApp = await prisma.apps.upsert({
-                where: {
-                    id,
-                },
-                update: {},
-                create: {
+            const createdApp = await prisma.apps.create({
+                data: {
                     id,
                     tp_id: tpId,
                     scope: [],
@@ -27,7 +23,6 @@ class AppService {
                     environmentId,
                 },
             });
-
             return createdApp;
         } catch (error: any) {
             return { error: 'Something went wrong while creating app' };

--- a/packages/backend/services/app.ts
+++ b/packages/backend/services/app.ts
@@ -1,0 +1,38 @@
+import { TP_ID } from '@prisma/client';
+import prisma from '../prisma/client';
+
+class AppService {
+    async createRevertAppForAccount({
+        userId,
+        tpId,
+        environment,
+    }: {
+        userId: string;
+        tpId: TP_ID;
+        environment: string;
+    }): Promise<any> {
+        const id = `${tpId}_${userId}_${environment}`;
+        const environmentId = `${userId}_${environment}`;
+        try {
+            const createdApp = await prisma.apps.upsert({
+                where: {
+                    id,
+                },
+                update: {},
+                create: {
+                    id,
+                    tp_id: tpId,
+                    scope: [],
+                    is_revert_app: true,
+                    environmentId,
+                },
+            });
+
+            return createdApp;
+        } catch (error: any) {
+            return { error: 'Something went wrong while creating app' };
+        }
+    }
+}
+
+export default new AppService();

--- a/packages/backend/services/auth.ts
+++ b/packages/backend/services/auth.ts
@@ -436,32 +436,6 @@ class AuthService {
                     },
                     include: { environments: true },
                 });
-                // Create default apps that don't yet exist. (don't create all apps)
-                // await Promise.all(
-                //     Object.keys(ENV).map((env) => {
-                //         Object.keys(TP_ID).map(async (tp) => {
-                //             try {
-                //                 const environment = account.environments?.find((e) => e.env === env)!;
-                //                 await prisma.apps.upsert({
-                //                     where: {
-                //                         id: `${tp}_${account.id}_${env}`,
-                //                     },
-                //                     update: {},
-                //                     create: {
-                //                         id: `${tp}_${account.id}_${env}`,
-                //                         tp_id: tp as TP_ID,
-                //                         scope: [],
-                //                         is_revert_app: true,
-                //                         environmentId: environment.id,
-                //                     },
-                //                 });
-                //                 // Create apps for both in development & production.
-                //             } catch (error: any) {
-                //                 logError(error);
-                //             }
-                //         });
-                //     })
-                // );
                 // Create Svix application for this account if it doesn't exist.
                 await config.svix?.application.getOrCreate({
                     name: accountId,

--- a/packages/backend/services/auth.ts
+++ b/packages/backend/services/auth.ts
@@ -436,32 +436,32 @@ class AuthService {
                     },
                     include: { environments: true },
                 });
-                // Create default apps that don't yet exist.
-                await Promise.all(
-                    Object.keys(ENV).map((env) => {
-                        Object.keys(TP_ID).map(async (tp) => {
-                            try {
-                                const environment = account.environments?.find((e) => e.env === env)!;
-                                await prisma.apps.upsert({
-                                    where: {
-                                        id: `${tp}_${account.id}_${env}`,
-                                    },
-                                    update: {},
-                                    create: {
-                                        id: `${tp}_${account.id}_${env}`,
-                                        tp_id: tp as TP_ID,
-                                        scope: [],
-                                        is_revert_app: true,
-                                        environmentId: environment.id,
-                                    },
-                                });
-                                // Create apps for both in development & production.
-                            } catch (error: any) {
-                                logError(error);
-                            }
-                        });
-                    })
-                );
+                // Create default apps that don't yet exist. (don't create all apps)
+                // await Promise.all(
+                //     Object.keys(ENV).map((env) => {
+                //         Object.keys(TP_ID).map(async (tp) => {
+                //             try {
+                //                 const environment = account.environments?.find((e) => e.env === env)!;
+                //                 await prisma.apps.upsert({
+                //                     where: {
+                //                         id: `${tp}_${account.id}_${env}`,
+                //                     },
+                //                     update: {},
+                //                     create: {
+                //                         id: `${tp}_${account.id}_${env}`,
+                //                         tp_id: tp as TP_ID,
+                //                         scope: [],
+                //                         is_revert_app: true,
+                //                         environmentId: environment.id,
+                //                     },
+                //                 });
+                //                 // Create apps for both in development & production.
+                //             } catch (error: any) {
+                //                 logError(error);
+                //             }
+                //         });
+                //     })
+                // );
                 // Create Svix application for this account if it doesn't exist.
                 await config.svix?.application.getOrCreate({
                     name: accountId,

--- a/packages/client/src/features/integration/AddIntegration.tsx
+++ b/packages/client/src/features/integration/AddIntegration.tsx
@@ -33,7 +33,7 @@ function AddIntegration({
                 <div className="overflow-hidden">
                     <Box component="div" sx={{ width: '70vw', padding: '2rem 3rem 0rem 3rem', marginBottom: '1.6rem' }}>
                         <h1 className="text-3xl font-bold text-[#fff]">Create Integration</h1>
-                        <span className="text-[#b1b8ba]">Click to Configure New Integration</span>
+                        <span className="text-[#b1b8ba]">Select and Click Create to Configure New Integration</span>
                     </Box>
                     <div className="pt-4 h-[36rem] overflow-scroll">
                         <div className="grid grid-cols-4 gap-8 justify-center content-center mx-8 ">
@@ -45,8 +45,8 @@ function AddIntegration({
                                         sx={{
                                             display: 'flex',
                                             justifyContent: 'space-between',
-                                            cursor: 'pointer',
                                             pointerEvents: isAppExist ? 'none' : 'initial',
+                                            cursor: isAppExist ? 'not-allowed' : 'pointer',
                                             backgroundColor: isAppExist && '#181d28',
                                         }}
                                     >

--- a/packages/client/src/features/integration/AddIntegration.tsx
+++ b/packages/client/src/features/integration/AddIntegration.tsx
@@ -26,7 +26,7 @@ function AddIntegration({
         >
             <>
                 <Box component="div" sx={{ margin: '3rem' }}>
-                    <h1 className="text-3xl font-bold mb-1 text-[#fff]">Create Integration</h1>
+                    <h1 className="text-3xl font-bold text-[#fff]">Create Integration</h1>
                     <span className="text-[#b1b8ba]">Click to Configure New Integration</span>
                 </Box>
                 <div className="grid grid-cols-4 gap-8 justify-center content-center mx-8">

--- a/packages/client/src/features/integration/AddIntegration.tsx
+++ b/packages/client/src/features/integration/AddIntegration.tsx
@@ -1,7 +1,8 @@
 import { Box } from '@mui/material';
 import Modal from '@mui/material/Modal';
-import React from 'react';
+import React, { useState } from 'react';
 import { appsInfo } from './enums/metadata';
+import { LoadingButton } from '@mui/lab';
 
 function AddIntegration({
     values,
@@ -13,58 +14,84 @@ function AddIntegration({
         apps: any;
     };
 }) {
+    const [selected, setSelected] = useState<string>('');
     const { init, setInit, handleCreation, apps } = values;
     const appsId = apps.map((app) => app.tp_id);
     return (
         <Modal
             open={init}
-            onClose={() => setInit(false)}
+            onClose={() => {
+                setInit(false);
+                setSelected('');
+            }}
             aria-labelledby="modal-modal-title"
             aria-describedby="modal-modal-description"
-            sx={{ backgroundColor: '#293347', width: '70vw', margin: '10vh 20vw 10vh 20vw' }}
-            className="rounded-xl overflow-scroll"
+            sx={{ backgroundColor: '#293347', width: '70vw', margin: '10vh 20vw 10vh 20vw', maxHeight: '74vh' }}
+            className="rounded-xl overflow-hidden"
         >
             <>
-                <Box component="div" sx={{ margin: '3rem' }}>
-                    <h1 className="text-3xl font-bold text-[#fff]">Create Integration</h1>
-                    <span className="text-[#b1b8ba]">Click to Configure New Integration</span>
-                </Box>
-                <div className="grid grid-cols-4 gap-8 justify-center content-center mx-8">
-                    {Object.keys(appsInfo).map((app, index) => {
-                        const isAppExist = appsId.includes(app);
-                        return (
-                            <Box
-                                key={index}
-                                sx={{
-                                    display: 'flex',
-                                    justifyContent: 'space-between',
-                                    cursor: 'pointer',
-                                    pointerEvents: isAppExist ? 'none' : 'initial',
-                                    backgroundColor: isAppExist && '#181d28',
-                                }}
-                            >
-                                <div
-                                    className="flex w-full justify-around items-center px-8 py-8 rounded-lg"
-                                    style={{
-                                        border: isAppExist ? '1px #ff8787 solid' : '0.5px #ced4da solid',
-                                    }}
-                                    onClick={() => {
-                                        handleCreation(app);
-                                    }}
-                                >
-                                    <img
-                                        width={100}
-                                        style={{
-                                            height: 40,
-                                            objectFit: 'scale-down',
+                <div className="overflow-hidden">
+                    <Box component="div" sx={{ width: '70vw', padding: '2rem 3rem 0rem 3rem', marginBottom: '1.6rem' }}>
+                        <h1 className="text-3xl font-bold text-[#fff]">Create Integration</h1>
+                        <span className="text-[#b1b8ba]">Click to Configure New Integration</span>
+                    </Box>
+                    <div className="pt-4 h-[36rem] overflow-scroll">
+                        <div className="grid grid-cols-4 gap-8 justify-center content-center mx-8 ">
+                            {Object.keys(appsInfo).map((app, index) => {
+                                const isAppExist = appsId.includes(app);
+                                return (
+                                    <Box
+                                        key={index}
+                                        sx={{
+                                            display: 'flex',
+                                            justifyContent: 'space-between',
+                                            cursor: 'pointer',
+                                            pointerEvents: isAppExist ? 'none' : 'initial',
+                                            backgroundColor: isAppExist && '#181d28',
                                         }}
-                                        alt={`${appsInfo[app].name} logo`}
-                                        src={appsInfo[app].logo}
-                                    />
-                                </div>
-                            </Box>
-                        );
-                    })}
+                                    >
+                                        <div
+                                            className="flex w-full justify-around items-center px-8 py-8 rounded-lg"
+                                            style={{
+                                                boxShadow:
+                                                    app === selected
+                                                        ? '0 0 0 3px #fff'
+                                                        : isAppExist
+                                                        ? '0 0 0 1px #ffa8a8'
+                                                        : '0 0 0 1px #ced4da',
+                                            }}
+                                            onClick={() => setSelected(app)}
+                                        >
+                                            <img
+                                                width={100}
+                                                style={{
+                                                    height: 40,
+                                                    objectFit: 'scale-down',
+                                                }}
+                                                alt={`${appsInfo[app].name} logo`}
+                                                src={appsInfo[app].logo}
+                                            />
+                                        </div>
+                                    </Box>
+                                );
+                            })}
+                        </div>
+                    </div>
+                    <div className="flex justify-end mr-8">
+                        <LoadingButton
+                            variant="contained"
+                            style={{
+                                background: '#293347',
+                                padding: '0.6rem 1.2rem',
+                            }}
+                            disabled={selected === ''}
+                            onClick={() => {
+                                handleCreation(selected);
+                            }}
+                        >
+                            Create
+                        </LoadingButton>
+                    </div>
                 </div>
             </>
         </Modal>

--- a/packages/client/src/features/integration/AddIntegration.tsx
+++ b/packages/client/src/features/integration/AddIntegration.tsx
@@ -46,7 +46,7 @@ function AddIntegration({
                                 <div
                                     className="flex w-full justify-around items-center px-8 py-8 rounded-lg"
                                     style={{
-                                        border: isAppExist ? '0.5px #ffa8a8 solid' : '0.5px #ced4da solid',
+                                        border: isAppExist ? '1px #ff8787 solid' : '0.5px #ced4da solid',
                                     }}
                                     onClick={() => {
                                         handleCreation(app);

--- a/packages/client/src/features/integration/AddIntegration.tsx
+++ b/packages/client/src/features/integration/AddIntegration.tsx
@@ -32,8 +32,10 @@ function AddIntegration({
             <>
                 <div className="overflow-hidden">
                     <Box component="div" sx={{ width: '70vw', padding: '2rem 3rem 0rem 3rem', marginBottom: '1.6rem' }}>
-                        <h1 className="text-3xl font-bold text-[#fff]">Create Integration</h1>
-                        <span className="text-[#b1b8ba]">Select and Click Create to Configure New Integration</span>
+                        <h1 className="text-3xl font-bold text-[#fff]">Create App</h1>
+                        <span className="text-[#b1b8ba]">
+                            Select and click add to configure a new app for an integration
+                        </span>
                     </Box>
                     <div className="pt-4 h-[36rem] overflow-scroll">
                         <div className="grid grid-cols-4 gap-8 justify-center content-center mx-8 ">
@@ -89,7 +91,7 @@ function AddIntegration({
                                 handleCreation(selected);
                             }}
                         >
-                            Create
+                            Add
                         </LoadingButton>
                     </div>
                 </div>

--- a/packages/client/src/features/integration/AddIntegration.tsx
+++ b/packages/client/src/features/integration/AddIntegration.tsx
@@ -1,75 +1,7 @@
 import { Box } from '@mui/material';
 import Modal from '@mui/material/Modal';
 import React from 'react';
-
-const integrations = [
-    {
-        name: 'Hubspot',
-        logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711548892/Revert/v8xy74cep10cjuitlnpk.png',
-        description: 'Configure your Hubspot App from here.',
-    },
-    {
-        name: 'Salesforce',
-        logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711548963/Revert/by6ckdbnibuniorebwxj.png',
-        description: 'Configure your Salesforce App from here.',
-    },
-    {
-        name: 'ZohoCRM',
-        logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549106/Revert/lig4v85hfhshob9w6z9z.png',
-        description: 'Configure your Zoho CRM App from here.',
-    },
-    {
-        name: 'Pipedrive',
-        logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711548714/Revert/opggbicfjuskkxnflysm.png',
-        description: 'Configure your Pipedrive App from here.',
-    },
-    {
-        name: 'Close CRM',
-        logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711548783/Revert/mrfg9qcxzh5r2iyatjdg.png',
-        description: 'Configure your Close CRM App from here.',
-    },
-    {
-        name: 'MS Dynamics Sales',
-        logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549741/Revert/pbvr2f2yszrt5ithbirb.png',
-        description: 'Configure your MS Dynamics 365 Sakes App from here.',
-    },
-    {
-        name: 'Slack Chat',
-        logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711550376/Revert/gei0ux6iptaf1nfxjfv2.png',
-        description: 'Configure your Slack Chat App from here.',
-    },
-    {
-        name: 'Discord Chat',
-        logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711550278/Revert/sgbdv2n10bajbykvtxl4.png',
-        description: 'Configure your Discord Chat App from here.',
-    },
-    {
-        name: 'Linear',
-        logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549244/Revert/v8r7gnqe0tzoozwbhnyn.png',
-        description: 'Configure your Linear Ticketing App from here.',
-    },
-    {
-        name: 'Clickup',
-        logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549293/Revert/ooo7iegqcrdkxgrclzjt.png',
-        description: 'Configure your Clickup Ticketing App from here.',
-    },
-    {
-        name: 'Jira',
-        logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549557/Revert/tsjway6elov5bv1tc5tk.png',
-        description: 'Configure your Jira Ticketing App from here.',
-    },
-    {
-        name: 'Trello',
-        logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549291/Revert/caydzlxzcitdu2n9yuea.png',
-        description: 'Configure your Trello Ticketing App from here.',
-    },
-
-    {
-        name: 'Bitbucket',
-        logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549311/Revert/cmqpors8m8tid9zpn9ak.png',
-        description: 'Configure your Bitbucket Ticketing App from here.',
-    },
-];
+import { appsInfo } from './enums/metadata';
 
 function AddIntegration({
     values,
@@ -77,9 +9,12 @@ function AddIntegration({
     values: {
         init: boolean;
         setInit: React.Dispatch<React.SetStateAction<boolean>>;
+        handleCreation: (id: string) => Promise<void>;
+        apps: any;
     };
 }) {
-    const { init, setInit } = values;
+    const { init, setInit, handleCreation, apps } = values;
+    const appsId = apps.map((app) => app.tp_id);
     return (
         <Modal
             open={init}
@@ -91,36 +26,45 @@ function AddIntegration({
         >
             <>
                 <Box component="div" sx={{ margin: '3rem' }}>
-                    <h1 className="text-3xl font-bold mb-3 text-[#fff]">Create Integration</h1>
-                    <span className="text-[#b1b8ba]"></span>
+                    <h1 className="text-3xl font-bold mb-1 text-[#fff]">Create Integration</h1>
+                    <span className="text-[#b1b8ba]">Click to Configure New Integration</span>
                 </Box>
                 <div className="grid grid-cols-4 gap-8 justify-center content-center mx-8">
-                    {integrations.map((integration, index) => (
-                        <Box
-                            key={index}
-                            sx={{
-                                display: 'flex',
-                                justifyContent: 'space-between',
-                            }}
-                        >
-                            <div
-                                className="flex w-full justify-around items-center px-8 py-8 rounded-lg"
-                                style={{
-                                    border: '1px #3E3E3E solid',
+                    {Object.keys(appsInfo).map((app, index) => {
+                        const isAppExist = appsId.includes(app);
+                        return (
+                            <Box
+                                key={index}
+                                sx={{
+                                    display: 'flex',
+                                    justifyContent: 'space-between',
+                                    cursor: 'pointer',
+                                    pointerEvents: isAppExist ? 'none' : 'initial',
+                                    backgroundColor: isAppExist && '#181d28',
                                 }}
                             >
-                                <img
-                                    width={100}
+                                <div
+                                    className="flex w-full justify-around items-center px-8 py-8 rounded-lg"
                                     style={{
-                                        height: 40,
-                                        objectFit: 'scale-down',
+                                        border: isAppExist ? '0.5px #ffa8a8 solid' : '0.5px #ced4da solid',
                                     }}
-                                    alt={`${integration.name} logo`}
-                                    src={integration.logo}
-                                />
-                            </div>
-                        </Box>
-                    ))}
+                                    onClick={() => {
+                                        handleCreation(app);
+                                    }}
+                                >
+                                    <img
+                                        width={100}
+                                        style={{
+                                            height: 40,
+                                            objectFit: 'scale-down',
+                                        }}
+                                        alt={`${appsInfo[app].name} logo`}
+                                        src={appsInfo[app].logo}
+                                    />
+                                </div>
+                            </Box>
+                        );
+                    })}
                 </div>
             </>
         </Modal>

--- a/packages/client/src/features/integration/AddIntegration.tsx
+++ b/packages/client/src/features/integration/AddIntegration.tsx
@@ -1,0 +1,62 @@
+import { Box } from '@mui/material';
+import Modal from '@mui/material/Modal';
+import React from 'react';
+
+function AddIntegration({
+    values,
+}: {
+    values: {
+        init: boolean;
+        setInit: React.Dispatch<React.SetStateAction<boolean>>;
+        integrations: Array<any>;
+    };
+}) {
+    const { init, setInit, integrations } = values;
+    return (
+        <Modal
+            open={init}
+            onClose={() => setInit(false)}
+            aria-labelledby="modal-modal-title"
+            aria-describedby="modal-modal-description"
+            sx={{ backgroundColor: '#293347', width: '70vw', margin: '10vh 20vw 10vh 20vw' }}
+            className="rounded-xl overflow-scroll"
+        >
+            <>
+                <Box component="div" sx={{ margin: '3rem' }}>
+                    <h1 className="text-3xl font-bold mb-3 text-[#fff]">Create Integration</h1>
+                    <span className="text-[#b1b8ba]"></span>
+                </Box>
+                <div className="grid grid-cols-4 gap-8 justify-center content-center mx-8">
+                    {integrations.map((integration, index) => (
+                        <Box
+                            key={index}
+                            sx={{
+                                display: 'flex',
+                                justifyContent: 'space-between',
+                            }}
+                        >
+                            <div
+                                className="flex w-full justify-around items-center px-8 py-8 rounded-lg"
+                                style={{
+                                    border: '1px #3E3E3E solid',
+                                }}
+                            >
+                                <img
+                                    width={100}
+                                    style={{
+                                        height: 40,
+                                        objectFit: 'scale-down',
+                                    }}
+                                    alt={`${integration.name} logo`}
+                                    src={integration.logo}
+                                />
+                            </div>
+                        </Box>
+                    ))}
+                </div>
+            </>
+        </Modal>
+    );
+}
+
+export default AddIntegration;

--- a/packages/client/src/features/integration/CreatedIntegration.tsx
+++ b/packages/client/src/features/integration/CreatedIntegration.tsx
@@ -16,7 +16,7 @@ function CreatedIntegration({
     if (!apps.length) {
         return (
             <div className="flex flex-col justify-center items-center h-[77vh] w-[80vw]">
-                <p>No Integration Created, Create and Configure your First Integration</p>
+                <p>No apps have been created; create and configure your first app for an integration</p>
             </div>
         );
     }

--- a/packages/client/src/features/integration/CreatedIntegration.tsx
+++ b/packages/client/src/features/integration/CreatedIntegration.tsx
@@ -14,7 +14,6 @@ function CreatedIntegration({
 }) {
     const { account, environment, handleOpen } = values;
     const apps = account.environments.find((x) => x.env === environment).apps;
-    console.log(apps);
     return (
         <div className="grid grid-cols-4 gap-8">
             {apps.map((app, index) => {

--- a/packages/client/src/features/integration/CreatedIntegration.tsx
+++ b/packages/client/src/features/integration/CreatedIntegration.tsx
@@ -7,13 +7,20 @@ function CreatedIntegration({
     values,
 }: {
     values: {
-        environment: string;
-        account: any;
+        apps: any;
         handleOpen: (appId: string) => void;
     };
 }) {
-    const { account, environment, handleOpen } = values;
-    const apps = account.environments.find((x) => x.env === environment).apps;
+    const { handleOpen, apps } = values;
+
+    if (!apps.length) {
+        return (
+            <div className="flex flex-col justify-center items-center h-[77vh] w-[80vw]">
+                <p>No Integration Created, Create and Configure your First Integration</p>
+            </div>
+        );
+    }
+
     return (
         <div className="grid grid-cols-4 gap-8">
             {apps.map((app, index) => {
@@ -26,8 +33,8 @@ function CreatedIntegration({
                             justifyContent: 'space-between',
                             alignItems: 'center',
                             padding: '2rem 0rem',
-                            maxWidth: '340px',
-                            maxHeight: '208px',
+                            maxWidth: '22rem',
+                            maxHeight: '12.5rem',
                         }}
                     >
                         <div

--- a/packages/client/src/features/integration/CreatedIntegration.tsx
+++ b/packages/client/src/features/integration/CreatedIntegration.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Box, IconButton } from '@mui/material';
+import SettingsIcon from '@mui/icons-material/Settings';
+import { appsInfo } from './enums/metadata';
+
+function CreatedIntegration({
+    values,
+}: {
+    values: {
+        environment: string;
+        account: any;
+        handleOpen: (appId: string) => void;
+    };
+}) {
+    const { account, environment, handleOpen } = values;
+    const apps = account.environments.find((x) => x.env === environment).apps;
+    console.log(apps);
+    return (
+        <div className="grid grid-cols-4 gap-8">
+            {apps.map((app, index) => {
+                const type = appsInfo?.[app.tp_id];
+                return (
+                    <Box
+                        key={index}
+                        sx={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            padding: '2rem 0rem',
+                            maxWidth: '340px',
+                            maxHeight: '208px',
+                        }}
+                    >
+                        <div
+                            style={{
+                                padding: 30,
+                                border: '1px #3E3E3E solid',
+                                borderRadius: 10,
+                                display: 'flex',
+                                flexDirection: 'column',
+                                alignItems: 'flex-start',
+                                height: 200,
+                                justifyContent: 'flex-end',
+                                position: 'relative',
+                            }}
+                        >
+                            <img
+                                width={100}
+                                style={{
+                                    maxHeight: 40,
+                                    objectFit: 'scale-down',
+                                    objectPosition: 'left',
+                                }}
+                                alt={`${type?.name} logo`}
+                                src={type?.logo}
+                            />
+                            <p className="font-bold mt-4">{type?.name}</p>
+                            <span className="text-[#b1b8ba]">{type?.description}</span>
+                            <IconButton
+                                onClick={() => handleOpen(app.tp_id)}
+                                style={{
+                                    color: '#94a3b8',
+                                    fontSize: 12,
+                                    position: 'absolute',
+                                    top: 10,
+                                    right: 10,
+                                }}
+                            >
+                                <SettingsIcon />
+                            </IconButton>
+                        </div>
+                    </Box>
+                );
+            })}
+        </div>
+    );
+}
+
+export default CreatedIntegration;

--- a/packages/client/src/features/integration/enums/metadata.ts
+++ b/packages/client/src/features/integration/enums/metadata.ts
@@ -1,3 +1,5 @@
+// TODO: Get this from API Later Point.
+
 export const appsInfo = {
     hubspot: {
         name: 'Hubspot',

--- a/packages/client/src/features/integration/enums/metadata.ts
+++ b/packages/client/src/features/integration/enums/metadata.ts
@@ -67,4 +67,9 @@ export const appsInfo = {
         logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549311/Revert/cmqpors8m8tid9zpn9ak.png',
         description: 'Configure your Bitbucket Ticketing App from here.',
     },
+    asana: {
+        name: 'Asana',
+        logo: '',
+        description: 'Configure your Asana App from here.',
+    },
 };

--- a/packages/client/src/features/integration/enums/metadata.ts
+++ b/packages/client/src/features/integration/enums/metadata.ts
@@ -1,130 +1,73 @@
-import { Box } from '@mui/material';
-import Modal from '@mui/material/Modal';
-import React from 'react';
-
-const integrations = [
-    {
+export const appsInfo = {
+    hubspot: {
         name: 'Hubspot',
         logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711548892/Revert/v8xy74cep10cjuitlnpk.png',
         description: 'Configure your Hubspot App from here.',
     },
-    {
+    sfdc: {
         name: 'Salesforce',
         logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711548963/Revert/by6ckdbnibuniorebwxj.png',
         description: 'Configure your Salesforce App from here.',
     },
-    {
+    zohocrm: {
         name: 'ZohoCRM',
         logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549106/Revert/lig4v85hfhshob9w6z9z.png',
         description: 'Configure your Zoho CRM App from here.',
     },
-    {
+    pipedrive: {
         name: 'Pipedrive',
         logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711548714/Revert/opggbicfjuskkxnflysm.png',
         description: 'Configure your Pipedrive App from here.',
     },
-    {
+    closecrm: {
         name: 'Close CRM',
         logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711548783/Revert/mrfg9qcxzh5r2iyatjdg.png',
         description: 'Configure your Close CRM App from here.',
     },
-    {
+    ms_dynamics_365_sales: {
         name: 'MS Dynamics Sales',
         logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549741/Revert/pbvr2f2yszrt5ithbirb.png',
         description: 'Configure your MS Dynamics 365 Sakes App from here.',
     },
-    {
+    slack: {
         name: 'Slack Chat',
         logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711550376/Revert/gei0ux6iptaf1nfxjfv2.png',
         description: 'Configure your Slack Chat App from here.',
     },
-    {
+    discord: {
         name: 'Discord Chat',
         logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711550278/Revert/sgbdv2n10bajbykvtxl4.png',
         description: 'Configure your Discord Chat App from here.',
     },
-    {
+    linear: {
         name: 'Linear',
         logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549244/Revert/v8r7gnqe0tzoozwbhnyn.png',
         description: 'Configure your Linear Ticketing App from here.',
     },
-    {
+    clickup: {
         name: 'Clickup',
         logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549293/Revert/ooo7iegqcrdkxgrclzjt.png',
         description: 'Configure your Clickup Ticketing App from here.',
     },
-    {
+    jira: {
         name: 'Jira',
         logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549557/Revert/tsjway6elov5bv1tc5tk.png',
         description: 'Configure your Jira Ticketing App from here.',
     },
-    {
+    trello: {
         name: 'Trello',
         logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549291/Revert/caydzlxzcitdu2n9yuea.png',
         description: 'Configure your Trello Ticketing App from here.',
     },
 
-    {
+    bitbucket: {
         name: 'Bitbucket',
         logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549311/Revert/cmqpors8m8tid9zpn9ak.png',
         description: 'Configure your Bitbucket Ticketing App from here.',
     },
-];
-
-function AddIntegration({
-    values,
-}: {
-    values: {
-        init: boolean;
-        setInit: React.Dispatch<React.SetStateAction<boolean>>;
-    };
-}) {
-    const { init, setInit } = values;
-    return (
-        <Modal
-            open={init}
-            onClose={() => setInit(false)}
-            aria-labelledby="modal-modal-title"
-            aria-describedby="modal-modal-description"
-            sx={{ backgroundColor: '#293347', width: '70vw', margin: '10vh 20vw 10vh 20vw' }}
-            className="rounded-xl overflow-scroll"
-        >
-            <>
-                <Box component="div" sx={{ margin: '3rem' }}>
-                    <h1 className="text-3xl font-bold mb-3 text-[#fff]">Create Integration</h1>
-                    <span className="text-[#b1b8ba]"></span>
-                </Box>
-                <div className="grid grid-cols-4 gap-8 justify-center content-center mx-8">
-                    {integrations.map((integration, index) => (
-                        <Box
-                            key={index}
-                            sx={{
-                                display: 'flex',
-                                justifyContent: 'space-between',
-                            }}
-                        >
-                            <div
-                                className="flex w-full justify-around items-center px-8 py-8 rounded-lg"
-                                style={{
-                                    border: '1px #3E3E3E solid',
-                                }}
-                            >
-                                <img
-                                    width={100}
-                                    style={{
-                                        height: 40,
-                                        objectFit: 'scale-down',
-                                    }}
-                                    alt={`${integration.name} logo`}
-                                    src={integration.logo}
-                                />
-                            </div>
-                        </Box>
-                    ))}
-                </div>
-            </>
-        </Modal>
-    );
-}
-
-export default AddIntegration;
+    asana: {
+        name: 'Asana',
+        logo: '',
+        description: 'Configure your Asana App from here.',
+    },
+};

--- a/packages/client/src/features/integration/enums/metadata.ts
+++ b/packages/client/src/features/integration/enums/metadata.ts
@@ -67,9 +67,9 @@ export const appsInfo = {
         logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549311/Revert/cmqpors8m8tid9zpn9ak.png',
         description: 'Configure your Bitbucket Ticketing App from here.',
     },
-    asana: {
-        name: 'Asana',
-        logo: '',
-        description: 'Configure your Asana App from here.',
-    },
+    // asana: {
+    //     name: 'Asana',
+    //     logo: '',
+    //     description: 'Configure your Asana App from here.',
+    // },
 };

--- a/packages/client/src/features/integration/enums/metadata.ts
+++ b/packages/client/src/features/integration/enums/metadata.ts
@@ -67,9 +67,4 @@ export const appsInfo = {
         logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549311/Revert/cmqpors8m8tid9zpn9ak.png',
         description: 'Configure your Bitbucket Ticketing App from here.',
     },
-    asana: {
-        name: 'Asana',
-        logo: '',
-        description: 'Configure your Asana App from here.',
-    },
 };

--- a/packages/client/src/home/environmentSelector.tsx
+++ b/packages/client/src/home/environmentSelector.tsx
@@ -64,6 +64,7 @@ export default function EnvironmentSelector({ environmentProp, setEnvironmentPro
                         <MenuItem
                             value={e.env}
                             className="capitalize"
+                            key={e.env}
                             sx={{
                                 background: '#080d19',
                                 '&:hover': {

--- a/packages/client/src/home/integrations.tsx
+++ b/packages/client/src/home/integrations.tsx
@@ -23,13 +23,26 @@ const Integrations = ({ environment }) => {
         setAppId(id);
         setOpen(true);
     };
-    // TODO: Get this from API.
+    const apps = account?.environments?.find((x) => x.env === environment).apps || [];
 
     const handleClose = async ({ refetchOnClose = false }: { refetchOnClose?: boolean }) => {
         setOpen(false);
         if (refetchOnClose) {
             await fetchAccount();
         }
+    };
+
+    const handleCreation = async (id: string) => {
+        const payload = {
+            userId: user.user?.id,
+            tpId: id,
+            environment,
+        };
+        const res = await fetch({
+            url: '/internal/account/apps',
+            method: 'POST',
+            payload,
+        });
     };
 
     const fetchAccount = React.useCallback(async () => {
@@ -87,19 +100,17 @@ const Integrations = ({ environment }) => {
             ) : (
                 <>
                     {account ? (
-                        <>
-                            <Box
-                                display="flex"
-                                flexDirection="column"
-                                justifyContent="center"
-                                height="80vh"
-                                alignItems="center"
-                            >
-                                <AddIntegration values={{ init, setInit }} />
-                                {/* <p>No Integration Created, Create and Configure your First Integration</p> */}
-                                <CreatedIntegration values={{ account, environment, handleOpen }} />
-                            </Box>
-                        </>
+                        <Box
+                            display="flex"
+                            flexDirection="column"
+                            justifyContent="center"
+                            height="80vh"
+                            alignItems="center"
+                        >
+                            <AddIntegration values={{ init, setInit, handleCreation, apps }} />
+                            {/* <p>No Integration Created, Create and Configure your First Integration</p> */}
+                            <CreatedIntegration values={{ account, environment, handleOpen }} />
+                        </Box>
                     ) : (
                         <>
                             <Box

--- a/packages/client/src/home/integrations.tsx
+++ b/packages/client/src/home/integrations.tsx
@@ -10,6 +10,7 @@ import { LOCALSTORAGE_KEYS } from '../data/localstorage';
 import { useApi } from '../data/hooks';
 import { LoadingButton } from '@mui/lab';
 import MainHeader from '../layout/MainHeader';
+import AddIntegration from '../features/integration/AddIntegration';
 
 const Integrations = ({ environment }) => {
     const user = useUser();
@@ -136,7 +137,7 @@ const Integrations = ({ environment }) => {
     }, [data]);
 
     return (
-        <div className="w-[80%]">
+        <div className="w-[80%] overflow-scroll over-scroll-auto">
             <MainHeader>
                 <Box
                     component="div"
@@ -144,7 +145,7 @@ const Integrations = ({ environment }) => {
                         display: 'flex',
                         flexDirection: 'column',
                     }}
-                    className="text-lg"
+                    className="text-lg mb-16"
                 >
                     <h1 className="text-3xl font-bold mb-3">Integrations</h1>
                     <span className="text-[#b1b8ba]">Configure & Manage your connected apps here.</span>
@@ -166,59 +167,72 @@ const Integrations = ({ environment }) => {
             ) : (
                 <>
                     {account ? (
-                        <div
-                            className="flex justify-between flex-wrap items-start gap-4"
-                            style={{ padding: '2rem 5rem', width: '80%' }}
-                        >
-                            {integrations.map((integration, index) => (
-                                <Box
-                                    key={index}
-                                    sx={{
-                                        display: 'flex',
-                                        justifyContent: 'space-between',
-                                        alignItems: 'center',
-                                        padding: '2rem 0rem',
-                                        maxWidth: '340px',
-                                        maxHeight: '208px',
-                                    }}
-                                >
-                                    <div
-                                        style={{
-                                            padding: 30,
-                                            border: '1px #3E3E3E solid',
-                                            borderRadius: 10,
-                                            display: 'flex',
-                                            flexDirection: 'column',
-                                            alignItems: 'flex-start',
-                                            height: 200,
-                                            justifyContent: 'flex-end',
-                                            position: 'relative',
-                                        }}
-                                    >
-                                        <img
-                                            width={100}
-                                            style={{ maxHeight: 40, objectFit: 'scale-down', objectPosition: 'left' }}
-                                            alt={`${integration.name} logo`}
-                                            src={integration.logo}
-                                        />
-                                        <p className="font-bold mt-4">{integration.name}</p>
-                                        <span className="text-[#b1b8ba]">{integration.description}</span>
-                                        <IconButton
-                                            onClick={integration.onClick}
-                                            style={{
-                                                color: '#94a3b8',
-                                                fontSize: 12,
-                                                position: 'absolute',
-                                                top: 10,
-                                                right: 10,
+                        <>
+                            <Box
+                                display="flex"
+                                flexDirection="column"
+                                justifyContent="center"
+                                height="80vh"
+                                alignItems="center"
+                            >
+                                <AddIntegration values={{ init, setInit, integrations }} />
+                                {/* <p>No Integration Created, Create and Configure your First Integration</p> */}
+                                <div className="grid grid-cols-4 gap-8">
+                                    {integrations.map((integration, index) => (
+                                        <Box
+                                            key={index}
+                                            sx={{
+                                                display: 'flex',
+                                                justifyContent: 'space-between',
+                                                alignItems: 'center',
+                                                padding: '2rem 0rem',
+                                                maxWidth: '340px',
+                                                maxHeight: '208px',
                                             }}
                                         >
-                                            <SettingsIcon />
-                                        </IconButton>
-                                    </div>
-                                </Box>
-                            ))}
-                        </div>
+                                            <div
+                                                style={{
+                                                    padding: 30,
+                                                    border: '1px #3E3E3E solid',
+                                                    borderRadius: 10,
+                                                    display: 'flex',
+                                                    flexDirection: 'column',
+                                                    alignItems: 'flex-start',
+                                                    height: 200,
+                                                    justifyContent: 'flex-end',
+                                                    position: 'relative',
+                                                }}
+                                            >
+                                                <img
+                                                    width={100}
+                                                    style={{
+                                                        maxHeight: 40,
+                                                        objectFit: 'scale-down',
+                                                        objectPosition: 'left',
+                                                    }}
+                                                    alt={`${integration.name} logo`}
+                                                    src={integration.logo}
+                                                />
+                                                <p className="font-bold mt-4">{integration.name}</p>
+                                                <span className="text-[#b1b8ba]">{integration.description}</span>
+                                                <IconButton
+                                                    onClick={integration.onClick}
+                                                    style={{
+                                                        color: '#94a3b8',
+                                                        fontSize: 12,
+                                                        position: 'absolute',
+                                                        top: 10,
+                                                        right: 10,
+                                                    }}
+                                                >
+                                                    <SettingsIcon />
+                                                </IconButton>
+                                            </div>
+                                        </Box>
+                                    ))}
+                                </div>
+                            </Box>
+                        </>
                     ) : (
                         <>
                             <Box

--- a/packages/client/src/home/integrations.tsx
+++ b/packages/client/src/home/integrations.tsx
@@ -13,7 +13,7 @@ import CreatedIntegration from '../features/integration/CreatedIntegration';
 
 const Integrations = ({ environment }) => {
     const user = useUser();
-    const { data, loading, fetch } = useApi();
+    const { data, loading, fetch, status } = useApi();
 
     const [account, setAccount] = useState<any>();
     const [open, setOpen] = React.useState(false);
@@ -38,11 +38,15 @@ const Integrations = ({ environment }) => {
             tpId: id,
             environment,
         };
-        const res = await fetch({
+        await fetch({
             url: '/internal/account/apps',
             method: 'POST',
             payload,
         });
+
+        if (status?.toString().startsWith('2')) {
+            setInit(false);
+        }
     };
 
     const fetchAccount = React.useCallback(async () => {
@@ -78,7 +82,7 @@ const Integrations = ({ environment }) => {
                         display: 'flex',
                         flexDirection: 'column',
                     }}
-                    className="text-lg mb-16"
+                    className="text-lg mb-8"
                 >
                     <h1 className="text-3xl font-bold mb-3">Integrations</h1>
                     <span className="text-[#b1b8ba]">Configure & Manage your connected apps here.</span>
@@ -100,16 +104,9 @@ const Integrations = ({ environment }) => {
             ) : (
                 <>
                     {account ? (
-                        <Box
-                            display="flex"
-                            flexDirection="column"
-                            justifyContent="center"
-                            height="80vh"
-                            alignItems="center"
-                        >
+                        <Box display="flex" flexDirection="column" justifyContent="center" alignItems="center">
                             <AddIntegration values={{ init, setInit, handleCreation, apps }} />
-                            {/* <p>No Integration Created, Create and Configure your First Integration</p> */}
-                            <CreatedIntegration values={{ account, environment, handleOpen }} />
+                            <CreatedIntegration values={{ apps, handleOpen }} />
                         </Box>
                     ) : (
                         <>

--- a/packages/client/src/home/integrations.tsx
+++ b/packages/client/src/home/integrations.tsx
@@ -8,6 +8,8 @@ import Modal from '@mui/material/Modal';
 import EditCredentials from './editCredentials';
 import { LOCALSTORAGE_KEYS } from '../data/localstorage';
 import { useApi } from '../data/hooks';
+import { LoadingButton } from '@mui/lab';
+import MainHeader from '../layout/MainHeader';
 
 const Integrations = ({ environment }) => {
     const user = useUser();
@@ -16,6 +18,7 @@ const Integrations = ({ environment }) => {
     const [account, setAccount] = useState<any>();
     const [open, setOpen] = React.useState(false);
     const [appId, setAppId] = useState<string>('sfdc');
+    const [init, setInit] = useState<boolean>(false);
 
     const handleOpen = (appId: string) => {
         setAppId(appId);
@@ -134,19 +137,28 @@ const Integrations = ({ environment }) => {
 
     return (
         <div className="w-[80%]">
-            <Box
-                component="div"
-                sx={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    padding: '0 5rem',
-                    paddingTop: '120px',
-                }}
-                className="text-lg"
-            >
-                <h1 className="text-3xl font-bold mb-3">Integrations</h1>
-                <span className="text-[#b1b8ba]">Configure & Manage your connected apps here.</span>
-            </Box>
+            <MainHeader>
+                <Box
+                    component="div"
+                    sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                    }}
+                    className="text-lg"
+                >
+                    <h1 className="text-3xl font-bold mb-3">Integrations</h1>
+                    <span className="text-[#b1b8ba]">Configure & Manage your connected apps here.</span>
+                </Box>
+                <Box>
+                    <LoadingButton
+                        variant="contained"
+                        style={{ background: '#293347', padding: '0.6rem 1.4rem' }}
+                        onClick={() => setInit(true)}
+                    >
+                        Create New Integration
+                    </LoadingButton>
+                </Box>
+            </MainHeader>
             {loading ? (
                 <div className="mt-10">
                     <TailSpin wrapperStyle={{ justifyContent: 'center' }} color="#1C1C1C" height={80} width={80} />

--- a/packages/client/src/home/integrations.tsx
+++ b/packages/client/src/home/integrations.tsx
@@ -94,7 +94,7 @@ const Integrations = ({ environment }) => {
                             style={{ background: '#293347', padding: '0.6rem 1.4rem' }}
                             onClick={() => setInit(true)}
                         >
-                            Create New Integration
+                            Create App
                         </LoadingButton>
                     </Box>
                 )}

--- a/packages/client/src/home/integrations.tsx
+++ b/packages/client/src/home/integrations.tsx
@@ -2,8 +2,6 @@ import React, { useEffect, useState } from 'react';
 import Box from '@mui/material/Box';
 import { useUser } from '@clerk/clerk-react';
 import { TailSpin } from 'react-loader-spinner';
-import { IconButton } from '@mui/material';
-import SettingsIcon from '@mui/icons-material/Settings';
 import Modal from '@mui/material/Modal';
 import EditCredentials from './editCredentials';
 import { LOCALSTORAGE_KEYS } from '../data/localstorage';
@@ -11,6 +9,7 @@ import { useApi } from '../data/hooks';
 import { LoadingButton } from '@mui/lab';
 import MainHeader from '../layout/MainHeader';
 import AddIntegration from '../features/integration/AddIntegration';
+import CreatedIntegration from '../features/integration/CreatedIntegration';
 
 const Integrations = ({ environment }) => {
     const user = useUser();
@@ -18,95 +17,14 @@ const Integrations = ({ environment }) => {
 
     const [account, setAccount] = useState<any>();
     const [open, setOpen] = React.useState(false);
-    const [appId, setAppId] = useState<string>('sfdc');
+    const [appId, setAppId] = useState<string>('');
     const [init, setInit] = useState<boolean>(false);
-
-    const handleOpen = (appId: string) => {
-        setAppId(appId);
+    const handleOpen = (id: string) => {
+        setAppId(id);
         setOpen(true);
     };
     // TODO: Get this from API.
-    const integrations = [
-        {
-            name: 'Hubspot',
-            logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711548892/Revert/v8xy74cep10cjuitlnpk.png',
-            description: 'Configure your Hubspot App from here.',
-            onClick: () => handleOpen('hubspot'),
-        },
-        {
-            name: 'Salesforce',
-            logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711548963/Revert/by6ckdbnibuniorebwxj.png',
-            description: 'Configure your Salesforce App from here.',
-            onClick: () => handleOpen('sfdc'),
-        },
-        {
-            name: 'ZohoCRM',
-            logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549106/Revert/lig4v85hfhshob9w6z9z.png',
-            description: 'Configure your Zoho CRM App from here.',
-            onClick: () => handleOpen('zohocrm'),
-        },
-        {
-            name: 'Pipedrive',
-            logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711548714/Revert/opggbicfjuskkxnflysm.png',
-            description: 'Configure your Pipedrive App from here.',
-            onClick: () => handleOpen('pipedrive'),
-        },
-        {
-            name: 'Close CRM',
-            logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711548783/Revert/mrfg9qcxzh5r2iyatjdg.png',
-            description: 'Configure your Close CRM App from here.',
-            onClick: () => handleOpen('closecrm'),
-        },
-        {
-            name: 'MS Dynamics Sales',
-            logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549741/Revert/pbvr2f2yszrt5ithbirb.png',
-            description: 'Configure your MS Dynamics 365 Sakes App from here.',
-            onClick: () => handleOpen('ms_dynamics_365_sales'),
-        },
-        {
-            name: 'Slack Chat',
-            logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711550376/Revert/gei0ux6iptaf1nfxjfv2.png',
-            description: 'Configure your Slack Chat App from here.',
-            onClick: () => handleOpen('slack'),
-        },
-        {
-            name: 'Discord Chat',
-            logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711550278/Revert/sgbdv2n10bajbykvtxl4.png',
-            description: 'Configure your Discord Chat App from here.',
-            onClick: () => handleOpen('discord'),
-        },
-        {
-            name: 'Linear',
-            logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549244/Revert/v8r7gnqe0tzoozwbhnyn.png',
-            description: 'Configure your Linear Ticketing App from here.',
-            onClick: () => handleOpen('linear'),
-        },
-        {
-            name: 'Clickup',
-            logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549293/Revert/ooo7iegqcrdkxgrclzjt.png',
-            description: 'Configure your Clickup Ticketing App from here.',
-            onClick: () => handleOpen('clickup'),
-        },
-        {
-            name: 'Jira',
-            logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549557/Revert/tsjway6elov5bv1tc5tk.png',
-            description: 'Configure your Jira Ticketing App from here.',
-            onClick: () => handleOpen('jira'),
-        },
-        {
-            name: 'Trello',
-            logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549291/Revert/caydzlxzcitdu2n9yuea.png',
-            description: 'Configure your Trello Ticketing App from here.',
-            onClick: () => handleOpen('trello'),
-        },
 
-        {
-            name: 'Bitbucket',
-            logo: 'https://res.cloudinary.com/dfcnic8wq/image/upload/v1711549311/Revert/cmqpors8m8tid9zpn9ak.png',
-            description: 'Configure your Bitbucket Ticketing App from here.',
-            onClick: () => handleOpen('bitbucket'),
-        },
-    ];
     const handleClose = async ({ refetchOnClose = false }: { refetchOnClose?: boolean }) => {
         setOpen(false);
         if (refetchOnClose) {
@@ -126,7 +44,9 @@ const Integrations = ({ environment }) => {
     }, [fetch, user.user?.id]);
 
     useEffect(() => {
-        if (open) return;
+        if (open) {
+            return;
+        }
         fetchAccount();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [open]);
@@ -175,62 +95,9 @@ const Integrations = ({ environment }) => {
                                 height="80vh"
                                 alignItems="center"
                             >
-                                <AddIntegration values={{ init, setInit, integrations }} />
+                                <AddIntegration values={{ init, setInit }} />
                                 {/* <p>No Integration Created, Create and Configure your First Integration</p> */}
-                                <div className="grid grid-cols-4 gap-8">
-                                    {integrations.map((integration, index) => (
-                                        <Box
-                                            key={index}
-                                            sx={{
-                                                display: 'flex',
-                                                justifyContent: 'space-between',
-                                                alignItems: 'center',
-                                                padding: '2rem 0rem',
-                                                maxWidth: '340px',
-                                                maxHeight: '208px',
-                                            }}
-                                        >
-                                            <div
-                                                style={{
-                                                    padding: 30,
-                                                    border: '1px #3E3E3E solid',
-                                                    borderRadius: 10,
-                                                    display: 'flex',
-                                                    flexDirection: 'column',
-                                                    alignItems: 'flex-start',
-                                                    height: 200,
-                                                    justifyContent: 'flex-end',
-                                                    position: 'relative',
-                                                }}
-                                            >
-                                                <img
-                                                    width={100}
-                                                    style={{
-                                                        maxHeight: 40,
-                                                        objectFit: 'scale-down',
-                                                        objectPosition: 'left',
-                                                    }}
-                                                    alt={`${integration.name} logo`}
-                                                    src={integration.logo}
-                                                />
-                                                <p className="font-bold mt-4">{integration.name}</p>
-                                                <span className="text-[#b1b8ba]">{integration.description}</span>
-                                                <IconButton
-                                                    onClick={integration.onClick}
-                                                    style={{
-                                                        color: '#94a3b8',
-                                                        fontSize: 12,
-                                                        position: 'absolute',
-                                                        top: 10,
-                                                        right: 10,
-                                                    }}
-                                                >
-                                                    <SettingsIcon />
-                                                </IconButton>
-                                            </div>
-                                        </Box>
-                                    ))}
-                                </div>
+                                <CreatedIntegration values={{ account, environment, handleOpen }} />
                             </Box>
                         </>
                     ) : (

--- a/packages/client/src/home/integrations.tsx
+++ b/packages/client/src/home/integrations.tsx
@@ -87,15 +87,17 @@ const Integrations = ({ environment }) => {
                     <h1 className="text-3xl font-bold mb-3">Integrations</h1>
                     <span className="text-[#b1b8ba]">Configure & Manage your connected apps here.</span>
                 </Box>
-                <Box>
-                    <LoadingButton
-                        variant="contained"
-                        style={{ background: '#293347', padding: '0.6rem 1.4rem' }}
-                        onClick={() => setInit(true)}
-                    >
-                        Create New Integration
-                    </LoadingButton>
-                </Box>
+                {!init && (
+                    <Box>
+                        <LoadingButton
+                            variant="contained"
+                            style={{ background: '#293347', padding: '0.6rem 1.4rem' }}
+                            onClick={() => setInit(true)}
+                        >
+                            Create New Integration
+                        </LoadingButton>
+                    </Box>
+                )}
             </MainHeader>
             {loading ? (
                 <div className="mt-10">

--- a/packages/client/src/home/navbar.tsx
+++ b/packages/client/src/home/navbar.tsx
@@ -9,20 +9,18 @@ import GitHubButton from 'react-github-btn';
 const Navbar = ({ workspaceName, environment, setEnvironment, environmentList }) => {
     return (
         <div id="top-navbar">
-            <Link to="/" className="flex items-center">
-                <img
-                    src={Logo}
-                    alt="revert_logo"
-                    className="w-[30px] h-[30px] ml-[24px] cursor-pointer mt-4 mb-3 mr-[24px]"
-                />
-                <span className="ml-[24px] mr-[12px] text-[#fff]">{workspaceName}</span>
-            </Link>
-            <div className="flex justify-center items-center">
+            <div className="flex justify-around items-center  ml-[1.5rem]">
+                <Link to="/" className="flex justify-evenly items-center">
+                    <img src={Logo} alt="revert_logo" className="w-[2rem] h-[2rem] mr-[1.5rem] cursor-pointer" />
+                    <p className="text-[#fff]">{workspaceName}</p>
+                </Link>
                 <EnvironmentSelector
                     environmentProp={environment}
                     setEnvironmentProp={setEnvironment}
                     environmentList={environmentList}
                 />
+            </div>
+            <div className="flex justify-center items-center">
                 <a
                     href={'https://docs.revert.dev'}
                     target="_blank"

--- a/packages/client/src/home/navbar.tsx
+++ b/packages/client/src/home/navbar.tsx
@@ -16,13 +16,13 @@ const Navbar = ({ workspaceName, environment, setEnvironment, environmentList })
                     className="w-[30px] h-[30px] ml-[24px] cursor-pointer mt-4 mb-3 mr-[24px]"
                 />
                 <span className="ml-[24px] mr-[12px] text-[#fff]">{workspaceName}</span>
+            </Link>
+            <div className="flex justify-center items-center">
                 <EnvironmentSelector
                     environmentProp={environment}
                     setEnvironmentProp={setEnvironment}
                     environmentList={environmentList}
                 />
-            </Link>
-            <div className="flex justify-center items-center">
                 <a
                     href={'https://docs.revert.dev'}
                     target="_blank"

--- a/packages/client/src/layout/MainHeader.tsx
+++ b/packages/client/src/layout/MainHeader.tsx
@@ -7,7 +7,7 @@ function MainHeader({ children }: { children: ReactNode }) {
             component="div"
             display="flex"
             flexDirection="row"
-            sx={{ margin: '0 5rem', marginTop: '120px', justifyContent: 'space-between' }}
+            sx={{ margin: '0 3rem', marginTop: '120px', justifyContent: 'space-between' }}
         >
             {children}
         </Box>

--- a/packages/client/src/layout/MainHeader.tsx
+++ b/packages/client/src/layout/MainHeader.tsx
@@ -1,0 +1,17 @@
+import Box from '@mui/material/Box';
+import React, { ReactNode } from 'react';
+
+function MainHeader({ children }: { children: ReactNode }) {
+    return (
+        <Box
+            component="div"
+            display="flex"
+            flexDirection="row"
+            sx={{ margin: '0 5rem', marginTop: '120px', justifyContent: 'space-between' }}
+        >
+            {children}
+        </Box>
+    );
+}
+
+export default MainHeader;

--- a/packages/client/src/layout/MainHeader.tsx
+++ b/packages/client/src/layout/MainHeader.tsx
@@ -7,7 +7,7 @@ function MainHeader({ children }: { children: ReactNode }) {
             component="div"
             display="flex"
             flexDirection="row"
-            sx={{ margin: '0 3rem', marginTop: '120px', justifyContent: 'space-between' }}
+            sx={{ padding: '0 3rem', paddingTop: '8rem', justifyContent: 'space-between' }}
         >
             {children}
         </Box>


### PR DESCRIPTION
### Description

- [x] Allow Revert Developers to Create Revert App. 
- [x] In Modal, Heading and Button remains fixed in case of overflow of Integration conversion to scroll.
Closes #496 
- [x] Fixes Env Selector rerendering issue on change of Env. 
- [x] UI to use Grid CSS to fix Grid view for Created Apps. 
- [x] Used float units (rem) and removed maximum hard coded px to rem values, for layout changed to use viewport units.

### Type of change
Closes #496
/claim #496

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published in downstream modules

### Screenshot / Video 

https://github.com/revertinc/revert/assets/65061890/a56e9fc6-b1ae-42bf-8345-91d85a8812a1