### PR TITLE
fix: created apps page to have 3 cols

### DIFF
--- a/packages/client/src/features/integration/CreatedIntegration.tsx
+++ b/packages/client/src/features/integration/CreatedIntegration.tsx
@@ -22,38 +22,21 @@ function CreatedIntegration({
     }
 
     return (
-        <div className="grid grid-cols-4 gap-8">
+        <div className="grid md:grid-cols-2 gap-y-8 gap-x-8 ml-12 mr-8 mb-8 justify-items-stretch lg:grid-cols-3">
             {apps.map((app, index) => {
                 const type = appsInfo?.[app.tp_id];
                 return (
-                    <Box
-                        key={index}
-                        sx={{
-                            display: 'flex',
-                            justifyContent: 'space-between',
-                            alignItems: 'center',
-                            padding: '2rem 0rem',
-                            maxWidth: '22rem',
-                            maxHeight: '12.5rem',
-                        }}
-                    >
+                    <Box key={index} className="flex items-center">
                         <div
+                            className="flex flex-col justify-end items-start h-[12.5rem] w-full relative px-5 py-10"
                             style={{
-                                padding: 30,
                                 border: '1px #3E3E3E solid',
                                 borderRadius: 10,
-                                display: 'flex',
-                                flexDirection: 'column',
-                                alignItems: 'flex-start',
-                                height: 200,
-                                justifyContent: 'flex-end',
-                                position: 'relative',
                             }}
                         >
                             <img
-                                width={100}
+                                className="max-h-[2rem] max-w-[7rem]"
                                 style={{
-                                    maxHeight: 40,
                                     objectFit: 'scale-down',
                                     objectPosition: 'left',
                                 }}

--- a/packages/client/src/home/integrations.tsx
+++ b/packages/client/src/home/integrations.tsx
@@ -74,7 +74,7 @@ const Integrations = ({ environment }) => {
     }, [data]);
 
     return (
-        <div className="w-[80%] overflow-scroll over-scroll-auto">
+        <div className="w-[80vw] overflow-scroll over-scroll-auto">
             <MainHeader>
                 <Box
                     component="div"
@@ -106,10 +106,12 @@ const Integrations = ({ environment }) => {
             ) : (
                 <>
                     {account ? (
-                        <Box display="flex" flexDirection="column" justifyContent="center" alignItems="center">
-                            <AddIntegration values={{ init, setInit, handleCreation, apps }} />
+                        <>
+                            <Box display="flex" flexDirection="column" justifyContent="center" alignItems="center">
+                                <AddIntegration values={{ init, setInit, handleCreation, apps }} />
+                            </Box>
                             <CreatedIntegration values={{ apps, handleOpen }} />
-                        </Box>
+                        </>
                     ) : (
                         <>
                             <Box

--- a/packages/client/src/layout/MainHeader.tsx
+++ b/packages/client/src/layout/MainHeader.tsx
@@ -7,7 +7,7 @@ function MainHeader({ children }: { children: ReactNode }) {
             component="div"
             display="flex"
             flexDirection="row"
-            sx={{ padding: '0 3rem', paddingTop: '8rem', justifyContent: 'space-between' }}
+            sx={{ margin: '0 3rem', marginTop: '8rem', justifyContent: 'space-between' }}
         >
             {children}
         </Box>


### PR DESCRIPTION
### Description
- [x] Change Created Apps Grid Layout to have 3 cols, and strecth the each container to fill in the grid cells.
- Relates #496 


https://github.com/revertinc/revert/assets/65061890/b6fba68a-4824-4764-97b6-6f28e75579e8



### Type of change
-   [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
