### PR TITLE
fix: connecting to revert on null props

### DIFF
--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -258,6 +258,13 @@ const createIntegrationBlock = function (self, integration) {
         };
 
         init = function (config) {
+            // checking if the config is valid
+            const { revertToken, tenantId } = config;
+
+            if (revertToken == undefined || revertToken == null || tenantId == undefined || tenantId == null) {
+                return;
+            }
+
             this.API_REVERT_PUBLIC_TOKEN = config.revertToken;
             this.closeAfterOAuthFlow = config.closeAfterOAuthFlow !== undefined ? config.closeAfterOAuthFlow : true; // TODO: Make this backend controlled.
             this.tenantId = config.tenantId;

--- a/packages/react/src/App.tsx
+++ b/packages/react/src/App.tsx
@@ -12,7 +12,7 @@ function App() {
         >
             <RevertConnect
                 config={{
-                    revertToken: 'pk_test_0396de2e-73a7-426c-ac5f-ba019eb1fc6a',
+                    revertToken: 'localPublicToken',
                     tenantId: 'testTenantId',
                     onClose: () => {
                         console.log('On close working!');

--- a/packages/react/src/App.tsx
+++ b/packages/react/src/App.tsx
@@ -1,6 +1,7 @@
 import RevertConnect from './lib/RevertConnect';
 
 function App() {
+    
     return (
         <div
             style={{
@@ -11,7 +12,7 @@ function App() {
         >
             <RevertConnect
                 config={{
-                    revertToken: 'localPublicToken',
+                    revertToken: 'pk_test_0396de2e-73a7-426c-ac5f-ba019eb1fc6a',
                     tenantId: 'testTenantId',
                     onClose: () => {
                         console.log('On close working!');

--- a/packages/react/src/lib/useRevertConnect.ts
+++ b/packages/react/src/lib/useRevertConnect.ts
@@ -13,7 +13,6 @@ if (typeof window !== 'undefined') {
 }
 
 declare var __CDN_PATH__: string;
-const REVERT_TOKEN_LENGTH = 44;
 
 export function useRevertConnectScript() {
     const [loading, setLoading] = useState(true);
@@ -46,17 +45,9 @@ export function useRevertConnectScript() {
 export default function useRevertConnect(props: useRevertConnectProps) {
     const { loading, error } = useRevertConnectScript();
     const [integrationsLoaded, setIntegrationsLoaded] = useState(false);
-    const { tenantId, revertToken } = props.config;
 
     useEffect(() => {
-        /* Todo: 
-            This is temporary solution and requires more to be done, We need a mechanism to fetch as we render (before paint), 
-            to know if revertToken and tenantId passed exist and its true.        
-        */
-        const isValidRevertToken = revertToken.length === REVERT_TOKEN_LENGTH;
-        const isValidTenantId = tenantId != 'null' && tenantId != undefined;
-        const isConfigPropValid = isValidRevertToken && isValidTenantId;
-        if (!loading && typeof window !== 'undefined' && window.Revert && window.Revert.init && isConfigPropValid) {
+        if (!loading && typeof window !== 'undefined' && window.Revert && window.Revert.init) {
             window.Revert.init({
                 ...props.config,
                 onLoad: () => {
@@ -75,6 +66,12 @@ export default function useRevertConnect(props: useRevertConnectProps) {
             console.error('Revert is not present');
             return;
         }
+
+        if (window.Revert && !window.Revert.getIntegrationsLoaded) {
+            console.error('Revert is not loaded');
+            return;
+        }
+
         window.Revert.open(integrationId);
     };
     return { open, error, loading: loading || !integrationsLoaded };

--- a/packages/react/src/lib/useRevertConnect.ts
+++ b/packages/react/src/lib/useRevertConnect.ts
@@ -13,6 +13,7 @@ if (typeof window !== 'undefined') {
 }
 
 declare var __CDN_PATH__: string;
+const REVERT_TOKEN_LENGTH = 44;
 
 export function useRevertConnectScript() {
     const [loading, setLoading] = useState(true);
@@ -45,9 +46,17 @@ export function useRevertConnectScript() {
 export default function useRevertConnect(props: useRevertConnectProps) {
     const { loading, error } = useRevertConnectScript();
     const [integrationsLoaded, setIntegrationsLoaded] = useState(false);
+    const { tenantId, revertToken } = props.config;
 
     useEffect(() => {
-        if (!loading && typeof window !== 'undefined' && window.Revert && window.Revert.init) {
+        /* Todo: 
+            This is temporary solution and requires more to be done, We need a mechanism to fetch as we render (before paint), 
+            to know if revertToken and tenantId passed exist and its true.        
+        */
+        const isValidRevertToken = revertToken.length === REVERT_TOKEN_LENGTH;
+        const isValidTenantId = tenantId != 'null' && tenantId != undefined;
+        const isConfigPropValid = isValidRevertToken && isValidTenantId;
+        if (!loading && typeof window !== 'undefined' && window.Revert && window.Revert.init && isConfigPropValid) {
             window.Revert.init({
                 ...props.config,
                 onLoad: () => {

--- a/packages/vue/src/App.vue
+++ b/packages/vue/src/App.vue
@@ -15,7 +15,7 @@ export default {
         return {
             config: {
                 revertToken: 'localPublicToken',
-                tenantId: null,
+                tenantId: "testTenantId",
             },
         };
     },

--- a/packages/vue/src/App.vue
+++ b/packages/vue/src/App.vue
@@ -15,7 +15,7 @@ export default {
         return {
             config: {
                 revertToken: 'localPublicToken',
-                tenantId: "testTenantId",
+                tenantId: 'testTenantId',
             },
         };
     },

--- a/packages/vue/src/App.vue
+++ b/packages/vue/src/App.vue
@@ -15,7 +15,7 @@ export default {
         return {
             config: {
                 revertToken: 'localPublicToken',
-                tenantId: 'testTenantId',
+                tenantId: null,
             },
         };
     },


### PR DESCRIPTION
### Description

- Allow connection only when config values are not null, undefined. 
- On the Initial Renders config props could be null or undefined that wouldn't mean they intend or passed that strict value.
- Handling "Revert is Loaded or not" on open, inOrder to not give console errors on every initial renders if the value is null or undefined.

- In React Example we are disabling the button -> Inorder to check comment out disabled in button.

### React
https://github.com/revertinc/revert/assets/65061890/6945c865-4d2d-4734-b1c2-9d1fad90051e

### Vue
https://github.com/revertinc/revert/assets/65061890/c4c614b0-f15d-4057-b870-600bf1e7d647





Fixes #564 

### Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
