### PR TITLE
fix: handle `closeAfterOAuthFlow` with `fieldMapping` account config

### DIFF
--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -582,10 +582,11 @@ const createIntegrationBlock = function (self, integration) {
 
         renderSuccessStage = function (fieldMappingData, integrationName, tenantToken) {
             console.log(fieldMappingData);
+            if (this.closeAfterOAuthFlow) {
+                return this.close();
+            }
+
             if (!(fieldMappingData.mappableFields || []).length) {
-                if (this.closeAfterOAuthFlow) {
-                    return this.close();
-                }
                 return this.renderDoneStage(integrationName);
             }
             const container = document.getElementById('revert-signin-container');


### PR DESCRIPTION
### Description
- when user is interested in fieldMappings explictly specify closeAfterOAuthFlow: false and if not specified it will assume customers are not interested in fieldMappings regardless of AccountFieldMappingsConfig. 

- Closes #576 

#### Four Cases: 
When FieldMapping Config is there:  
- `closeAfterOAuthFlow: true`: customers are not interested in fieldMappings regardless of config.
- `closeAfterOAuthFlow: false`: customers are interested in fieldMappings.

When FiledMapping Config is not there (Attaching Demo of this as it is little tricky): 
- `closeAfterOAuthFlow: true`: customers are not interested in fieldMappings  it will close.
- `closeAfterOAuthFlow: false`: customers are interested in fieldMappings but there is not config so it will show the container to close but won't show the filedMappings.

### FieldMappingConfig: false(not there), closeAfterOAuthFlow: true

https://github.com/revertinc/revert/assets/65061890/c5c7682c-b450-40d9-8cf0-537b2bb645a7

### FieldMappingConfig: false(not there), closeAfterOAuthFlow: false

https://github.com/revertinc/revert/assets/65061890/8703e409-87a6-4def-b05a-56e60a994578


### Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
