### PR TITLE
fix: Webhook endpoints to handle unauthorized API access

### DIFF
--- a/packages/backend/services/connection.ts
+++ b/packages/backend/services/connection.ts
@@ -194,6 +194,11 @@ const connectionService = new ConnectionService({
                     private_token: String(token),
                 },
             });
+
+            if (!environment) {
+                throw new UnAuthorizedError({ error: 'Api unauthorized' });
+            }
+
             const svixAppId = environment?.accountId!;
             const secret = `whsec_${Buffer.from(uuidv4()).toString('base64')}`;
             const webhook = await config.svix!.endpoint.create(svixAppId, {
@@ -231,6 +236,11 @@ const connectionService = new ConnectionService({
                     private_token: String(token),
                 },
             });
+
+            if (!environment) {
+                throw new UnAuthorizedError({ error: 'Api unauthorized' });
+            }
+
             const svixAppId = environment?.accountId!;
             const webhook = await config.svix!.endpoint.get(svixAppId, String(tenantId));
             res.send({ status: 'ok', webhook: webhook });
@@ -254,6 +264,11 @@ const connectionService = new ConnectionService({
                     private_token: String(token),
                 },
             });
+
+            if (!environment) {
+                throw new UnAuthorizedError({ error: 'Api unauthorized' });
+            }
+
             const svixAppId = environment?.accountId!;
             await config.svix!.endpoint.delete(svixAppId, webhookId);
             res.send({ status: 'ok' });


### PR DESCRIPTION
### Description

- Now it won't give `"field": "Required parameter appId was null or undefined when calling v1EndpointCreate."` and will give understandable response object.

- Fixes: issue in sentry - eventId 5bd35d6f

### Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules


https://github.com/revertinc/revert/assets/65061890/4250abf4-df48-45a3-b0f6-c65e643c429a


